### PR TITLE
Add external GPS provider

### DIFF
--- a/UnityProject/tfg/Assets/Scenes/MainScene.unity
+++ b/UnityProject/tfg/Assets/Scenes/MainScene.unity
@@ -205,6 +205,55 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 6484816944661230505, guid: 86a5bf68cb51f4e44bd3893bd22a2ba7, type: 3}
   m_PrefabInstance: {fileID: 3001774293689589082}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &294844434
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 294844436}
+  - component: {fileID: 294844435}
+  m_Layer: 0
+  m_Name: ExternalGpsProvider
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &294844435
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 294844434}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 20477a32a801dba4fb4e4182908aa8ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  hudController: {fileID: 392099730}
+  gpsEndpointUrl: http://127.0.0.1:5000/latest
+  refreshSeconds: 1
+  requestTimeoutSeconds: 2
+  logGpsToConsole: 1
+--- !u!4 &294844436
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 294844434}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -0.41524777, y: 1.5363626, z: 9.485518}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &392099729
 GameObject:
   m_ObjectHideFlags: 0
@@ -1310,3 +1359,4 @@ SceneRoots:
   - {fileID: 3001774293689589082}
   - {fileID: 392099731}
   - {fileID: 74395272}
+  - {fileID: 294844436}

--- a/UnityProject/tfg/Assets/Scripts/Domain/Models/AltitudeQuality.cs
+++ b/UnityProject/tfg/Assets/Scripts/Domain/Models/AltitudeQuality.cs
@@ -1,0 +1,9 @@
+namespace TFG.ARVisor.Domain.Models
+{
+    public enum AltitudeQuality
+    {
+        Good,
+        Unreliable,
+        Missing
+    }
+}

--- a/UnityProject/tfg/Assets/Scripts/Domain/Models/AltitudeQuality.cs.meta
+++ b/UnityProject/tfg/Assets/Scripts/Domain/Models/AltitudeQuality.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 274715df20d94214f9814bbdf3343f55
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/tfg/Assets/Scripts/Domain/Models/OwnshipGeoState.cs
+++ b/UnityProject/tfg/Assets/Scripts/Domain/Models/OwnshipGeoState.cs
@@ -1,0 +1,38 @@
+namespace TFG.ARVisor.Domain.Models
+{
+    public class OwnshipGeoState
+    {
+        public double Latitude { get; }
+        public double Longitude { get; }
+        public double? AltitudeMeters { get; }
+        public long TimestampUtc { get; }
+        public AltitudeQuality AltitudeQuality { get; }
+
+        public OwnshipMode Mode
+        {
+            get
+            {
+                if (AltitudeQuality == AltitudeQuality.Good && AltitudeMeters.HasValue)
+                {
+                    return OwnshipMode.Mode3D;
+                }
+
+                return OwnshipMode.Mode2D;
+            }
+        }
+
+        public OwnshipGeoState(
+            double latitude,
+            double longitude,
+            double? altitudeMeters,
+            long timestampUtc,
+            AltitudeQuality altitudeQuality)
+        {
+            Latitude = latitude;
+            Longitude = longitude;
+            AltitudeMeters = altitudeMeters;
+            TimestampUtc = timestampUtc;
+            AltitudeQuality = altitudeQuality;
+        }
+    }
+}

--- a/UnityProject/tfg/Assets/Scripts/Domain/Models/OwnshipGeoState.cs.meta
+++ b/UnityProject/tfg/Assets/Scripts/Domain/Models/OwnshipGeoState.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 99a6fdbca46177d4c8fdfe0f0e3985bc
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/tfg/Assets/Scripts/Domain/Models/OwnshipMode.cs
+++ b/UnityProject/tfg/Assets/Scripts/Domain/Models/OwnshipMode.cs
@@ -1,0 +1,8 @@
+namespace TFG.ARVisor.Domain.Models
+{
+    public enum OwnshipMode
+    {
+        Mode2D,
+        Mode3D
+    }
+}

--- a/UnityProject/tfg/Assets/Scripts/Domain/Models/OwnshipMode.cs.meta
+++ b/UnityProject/tfg/Assets/Scripts/Domain/Models/OwnshipMode.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 83702b46ebd74fa4eb316dd582a68726
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/tfg/Assets/Scripts/Infrastructure/Infrastructure.meta
+++ b/UnityProject/tfg/Assets/Scripts/Infrastructure/Infrastructure.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8350e9d05e325b04da39d7f00349fa09
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/tfg/Assets/Scripts/Infrastructure/Infrastructure/GPS.meta
+++ b/UnityProject/tfg/Assets/Scripts/Infrastructure/Infrastructure/GPS.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3a903e57fe36f5c49937717d663e2e43
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/tfg/Assets/Scripts/Infrastructure/Infrastructure/GPS/ExternalGpsProvider.cs
+++ b/UnityProject/tfg/Assets/Scripts/Infrastructure/Infrastructure/GPS/ExternalGpsProvider.cs
@@ -1,0 +1,156 @@
+using System;
+using System.Collections;
+using TFG.ARVisor.Domain.Models;
+using TFG.ARVisor.Presentation.HUD;
+using UnityEngine;
+using UnityEngine.Networking;
+
+namespace TFG.ARVisor.Infrastructure.Gps
+{
+    public class ExternalGpsProvider : MonoBehaviour
+    {
+        [Header("References")]
+        [SerializeField] private HudController hudController;
+
+        [Header("GPS Endpoint")]
+        [SerializeField] private string gpsEndpointUrl = "http://192.168.1.100:5000/latest";
+
+        [Header("Settings")]
+        [SerializeField] private float refreshSeconds = 1f;
+        [SerializeField] private int requestTimeoutSeconds = 2;
+        [SerializeField] private bool logGpsToConsole = true;
+
+        public OwnshipGeoState CurrentState { get; private set; }
+
+        private void Start()
+        {
+            StartCoroutine(PollGpsLoop());
+        }
+
+        private IEnumerator PollGpsLoop()
+        {
+            while (true)
+            {
+                yield return FetchLatestGps();
+                yield return new WaitForSeconds(refreshSeconds);
+            }
+        }
+
+        private IEnumerator FetchLatestGps()
+        {
+            if (string.IsNullOrWhiteSpace(gpsEndpointUrl))
+            {
+                UpdateHudWaiting();
+                yield break;
+            }
+
+            using UnityWebRequest request = UnityWebRequest.Get(gpsEndpointUrl);
+            request.timeout = requestTimeoutSeconds;
+
+            yield return request.SendWebRequest();
+
+            if (request.result != UnityWebRequest.Result.Success)
+            {
+                Debug.LogWarning($"GPS request failed: {request.error}");
+                UpdateHudWaiting();
+                yield break;
+            }
+
+            string json = request.downloadHandler.text;
+
+            try
+            {
+                GpsPayload payload = JsonUtility.FromJson<GpsPayload>(json);
+
+                AltitudeQuality altitudeQuality = GetAltitudeQuality(payload);
+
+                double? altitudeMeters = payload.hasAltitude
+                    ? payload.alt
+                    : null;
+
+                long timestamp = payload.timestamp > 0
+                    ? payload.timestamp
+                    : DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+
+                CurrentState = new OwnshipGeoState(
+                    payload.lat,
+                    payload.lon,
+                    altitudeMeters,
+                    timestamp,
+                    altitudeQuality
+                );
+
+                UpdateHudWithGps();
+
+                if (logGpsToConsole)
+                {
+                    Debug.Log(
+                        $"GPS REAL -> Lat: {CurrentState.Latitude}, Lon: {CurrentState.Longitude}, " +
+                        $"Alt: {CurrentState.AltitudeMeters}, Mode: {CurrentState.Mode}"
+                    );
+                }
+            }
+            catch (Exception exception)
+            {
+                Debug.LogWarning($"Invalid GPS payload: {exception.Message}");
+                UpdateHudWaiting();
+            }
+        }
+
+        private AltitudeQuality GetAltitudeQuality(GpsPayload payload)
+        {
+            if (!payload.hasAltitude)
+            {
+                return AltitudeQuality.Missing;
+            }
+
+            return payload.altitudeReliable
+                ? AltitudeQuality.Good
+                : AltitudeQuality.Unreliable;
+        }
+
+        private void UpdateHudWithGps()
+        {
+            if (hudController == null || CurrentState == null)
+            {
+                return;
+            }
+
+            string modeText = CurrentState.Mode == OwnshipMode.Mode3D ? "3D" : "2D";
+            string updateRateText = $"{1f / refreshSeconds:0.#} Hz";
+
+            hudController.RenderSystemStatus(
+                status: "ONLINE",
+                gpsStatus: "REAL",
+                mode: modeText,
+                updateRate: updateRateText
+            );
+        }
+
+        private void UpdateHudWaiting()
+        {
+            if (hudController == null)
+            {
+                return;
+            }
+
+            hudController.RenderSystemStatus(
+                status: "ONLINE",
+                gpsStatus: "WAIT",
+                mode: "--",
+                updateRate: $"{1f / refreshSeconds:0.#} Hz"
+            );
+        }
+
+        [Serializable]
+        private class GpsPayload
+        {
+            public double lat;
+            public double lon;
+            public double alt;
+            public bool hasAltitude;
+            public bool altitudeReliable;
+            public long timestamp;
+        }
+    }
+}

--- a/UnityProject/tfg/Assets/Scripts/Infrastructure/Infrastructure/GPS/ExternalGpsProvider.cs.meta
+++ b/UnityProject/tfg/Assets/Scripts/Infrastructure/Infrastructure/GPS/ExternalGpsProvider.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 20477a32a801dba4fb4e4182908aa8ff
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/tfg/Assets/XR/Resources/XRSimulationRuntimeSettings.asset.meta
+++ b/UnityProject/tfg/Assets/XR/Resources/XRSimulationRuntimeSettings.asset.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 782b14e43b4629340bf7d31eff0c02f2
+guid: bdd2d5582a7266247a4862ff7ae4b3cc
 NativeFormatImporter:
   externalObjects: {}
   mainObjectFileID: 11400000

--- a/UnityProject/tfg/Assets/XR/Temp.meta
+++ b/UnityProject/tfg/Assets/XR/Temp.meta
@@ -1,8 +1,8 @@
 fileFormatVersion: 2
-guid: afd8a4a2095c02346bf7660b288023bf
-NativeFormatImporter:
+guid: f6a46b693b5be6b44afb08a5006feff7
+folderAsset: yes
+DefaultImporter:
   externalObjects: {}
-  mainObjectFileID: 11400000
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/UnityProject/tfg/ProjectSettings/ProjectSettings.asset
+++ b/UnityProject/tfg/ProjectSettings/ProjectSettings.asset
@@ -144,9 +144,6 @@ PlayerSettings:
   bundleVersion: 1.0.0
   preloadedAssets:
   - {fileID: 11400000, guid: f8a442de0c8906f4d9c00184993fc289, type: 2}
-  - {fileID: -4637038883354861042, guid: 68b8576ba099b294d90889251a4a15ba, type: 2}
-  - {fileID: 11400000, guid: 56a98106ce58f09459a9990007b50acb, type: 2}
-  - {fileID: 6482856677600133674, guid: 8b07288ba6be24e448175f41e3629239, type: 2}
   metroInputSource: 0
   wsaTransparentSwapchain: 0
   m_HolographicPauseOnTrackingLoss: 1

--- a/start_gps_tools.bat
+++ b/start_gps_tools.bat
@@ -1,0 +1,35 @@
+@echo off
+title TFG AR Visor - GPS Tools Launcher
+
+REM ============================================================
+REM TFG AR VISOR - GPS TOOLS LAUNCHER
+REM ------------------------------------------------------------
+REM Este script abre automaticamente las herramientas necesarias
+REM para probar el envio de GPS desde el smartphone hacia Unity.
+REM
+REM 1. Abre el servidor local Python en el puerto 5000.
+REM 2. Abre ngrok para exponer ese servidor mediante HTTPS.
+REM
+REM El movil enviara el GPS a la URL HTTPS de ngrok.
+REM Unity leera los datos desde http://127.0.0.1:5000/latest
+REM ============================================================
+
+set "REPO_DIR=%~dp0"
+
+echo Iniciando servidor GPS...
+start "GPS Server" powershell -NoExit -Command "Set-Location -LiteralPath '%REPO_DIR%'; python 'tools/gps-server/gps_server.py'"
+
+timeout /t 2 > nul
+
+echo Iniciando ngrok...
+start "ngrok GPS Tunnel" powershell -NoExit -Command "& 'D:\ngrok.exe' http 5000"
+
+echo.
+echo Herramientas iniciadas.
+echo.
+echo 1. Copia la URL HTTPS que aparezca en la ventana de ngrok.
+echo 2. Abrela en el movil.
+echo 3. Permite la ubicacion.
+echo 4. En Unity usa: http://127.0.0.1:5000/latest
+echo.
+pause

--- a/tools/gps-server/gps_server.py
+++ b/tools/gps-server/gps_server.py
@@ -1,0 +1,167 @@
+from http.server import BaseHTTPRequestHandler, HTTPServer
+import json
+import time
+
+latest_gps = None
+
+
+HTML_PAGE = """
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>TFG AR Visor GPS Sender</title>
+</head>
+<body>
+    <h2>TFG AR Visor - GPS Sender</h2>
+    <p id="status">Esperando permiso de ubicación...</p>
+    <pre id="data"></pre>
+
+    <script>
+        const statusEl = document.getElementById("status");
+        const dataEl = document.getElementById("data");
+
+        function sendPosition(position) {
+            const coords = position.coords;
+
+            const payload = {
+                lat: coords.latitude,
+                lon: coords.longitude,
+                alt: coords.altitude ?? 0,
+                hasAltitude: coords.altitude !== null,
+                altitudeReliable: coords.altitudeAccuracy !== null ? coords.altitudeAccuracy <= 80 : false,
+                timestamp: Math.floor(Date.now() / 1000)
+            };
+
+            fetch("/update", {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json"
+                },
+                body: JSON.stringify(payload)
+            })
+            .then(() => {
+                statusEl.innerText = "GPS enviado correctamente";
+                dataEl.innerText = JSON.stringify(payload, null, 2);
+            })
+            .catch(error => {
+                statusEl.innerText = "Error enviando GPS: " + error;
+            });
+        }
+
+        function handleError(error) {
+            statusEl.innerText = "Error GPS: " + error.message;
+        }
+
+        if ("geolocation" in navigator) {
+            navigator.geolocation.watchPosition(
+                sendPosition,
+                handleError,
+                {
+                    enableHighAccuracy: true,
+                    maximumAge: 1000,
+                    timeout: 5000
+                }
+            );
+        } else {
+            statusEl.innerText = "Este navegador no soporta geolocalización.";
+        }
+    </script>
+</body>
+</html>
+"""
+
+
+class GpsRequestHandler(BaseHTTPRequestHandler):
+    def _set_headers(self, status_code=200, content_type="application/json"):
+        self.send_response(status_code)
+        self.send_header("Content-Type", content_type)
+        self.send_header("Access-Control-Allow-Origin", "*")
+        self.send_header("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+        self.send_header("Access-Control-Allow-Headers", "Content-Type")
+        self.end_headers()
+
+    def do_OPTIONS(self):
+        self._set_headers(200)
+
+    def do_GET(self):
+        global latest_gps
+
+        if self.path == "/":
+            self._set_headers(200, "text/html")
+            self.wfile.write(HTML_PAGE.encode("utf-8"))
+            return
+
+        if self.path == "/latest":
+            if latest_gps is None:
+                self._set_headers(404)
+                self.wfile.write(json.dumps({
+                    "error": "No GPS data received yet"
+                }).encode("utf-8"))
+                return
+
+            self._set_headers(200)
+            self.wfile.write(json.dumps(latest_gps).encode("utf-8"))
+            return
+
+        self._set_headers(404)
+        self.wfile.write(json.dumps({
+            "error": "Not found"
+        }).encode("utf-8"))
+
+    def do_POST(self):
+        global latest_gps
+
+        if self.path != "/update":
+            self._set_headers(404)
+            self.wfile.write(json.dumps({
+                "error": "Not found"
+            }).encode("utf-8"))
+            return
+
+        content_length = int(self.headers.get("Content-Length", 0))
+        body = self.rfile.read(content_length)
+
+        try:
+            payload = json.loads(body.decode("utf-8"))
+
+            latest_gps = {
+                "lat": float(payload["lat"]),
+                "lon": float(payload["lon"]),
+                "alt": float(payload.get("alt", 0)),
+                "hasAltitude": bool(payload.get("hasAltitude", False)),
+                "altitudeReliable": bool(payload.get("altitudeReliable", False)),
+                "timestamp": int(payload.get("timestamp", int(time.time())))
+            }
+
+            print("GPS actualizado:", latest_gps)
+
+            self._set_headers(200)
+            self.wfile.write(json.dumps({
+                "status": "ok",
+                "latest": latest_gps
+            }).encode("utf-8"))
+
+        except Exception as exception:
+            self._set_headers(400)
+            self.wfile.write(json.dumps({
+                "error": str(exception)
+            }).encode("utf-8"))
+
+
+def run_server():
+    host = "0.0.0.0"
+    port = 5000
+
+    server = HTTPServer((host, port), GpsRequestHandler)
+
+    print("Servidor GPS iniciado")
+    print(f"Escuchando en http://{host}:{port}")
+    print("Desde este PC: http://localhost:5000")
+    print("Desde el móvil/Quest: usa la IP local del PC, por ejemplo http://192.168.1.X:5000")
+
+    server.serve_forever()
+
+
+if __name__ == "__main__":
+    run_server()


### PR DESCRIPTION
## Qué se ha hecho

- Se han creado los modelos de posición propia del sistema.
- Se ha añadido el proveedor externo de GPS para recibir datos desde una URL configurable.
- Se ha creado un servidor local para recibir la posición GPS desde un smartphone.
- Se ha añadido un lanzador automático para iniciar el servidor GPS y ngrok.
- El HUD ya puede mostrar `GPS REAL` y cambiar entre modo 2D/3D según la fiabilidad de la altitud.

## Pruebas realizadas

- Probado envío de GPS desde smartphone mediante URL HTTPS de ngrok.
- Verificado que Unity recibe la posición real.
- Verificado que el HUD muestra `GPS REAL`.
- Verificado que el sistema entra en `MODE 2D` cuando la altitud no es fiable.

## Próximo paso

- Generar una zona de búsqueda alrededor de la posición propia para consultar OpenSky.