### PR TITLE
Add OpenSky bounding box and current traffic request

### DIFF
--- a/UnityProject/tfg/Assets/Scenes/MainScene.unity
+++ b/UnityProject/tfg/Assets/Scenes/MainScene.unity
@@ -302,6 +302,55 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &671746209
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 671746211}
+  - component: {fileID: 671746210}
+  m_Layer: 0
+  m_Name: OpenSkyQueryPreview
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &671746210
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 671746209}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f72782098afb26e48a2a02aa757f0ac0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  gpsProvider: {fileID: 294844435}
+  openSkyBaseUrl: https://opensky-network.org/api/states/all
+  searchRadiusKm: 50
+  refreshSeconds: 3
+  logToConsole: 1
+--- !u!4 &671746211
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 671746209}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -0.41524777, y: 1.5363626, z: 9.485518}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &729130563
 GameObject:
   m_ObjectHideFlags: 0
@@ -1360,3 +1409,4 @@ SceneRoots:
   - {fileID: 392099731}
   - {fileID: 74395272}
   - {fileID: 294844436}
+  - {fileID: 671746211}

--- a/UnityProject/tfg/Assets/Scripts/Domain/Models/GeoBoundingBox.cs
+++ b/UnityProject/tfg/Assets/Scripts/Domain/Models/GeoBoundingBox.cs
@@ -1,0 +1,58 @@
+/*
+ * GeoBoundingBox.cs
+ * ------------------------------------------------------------
+ * Este modelo representa una caja geográfica delimitada por una
+ * latitud mínima, longitud mínima, latitud máxima y longitud máxima.
+ *
+ * Se utiliza para consultar APIs externas como OpenSky, evitando
+ * pedir tráfico aéreo mundial y limitando la búsqueda a una zona
+ * cercana a la posición propia del usuario/avión.
+ *
+ * Importante:
+ * OpenSky espera los números decimales con punto, no con coma.
+ * Por eso se usa CultureInfo.InvariantCulture al generar la query.
+ */
+
+using System.Globalization;
+
+namespace TFG.ARVisor.Domain.Models
+{
+    public class GeoBoundingBox
+    {
+        public double MinLatitude { get; }
+        public double MinLongitude { get; }
+        public double MaxLatitude { get; }
+        public double MaxLongitude { get; }
+
+        /// <summary>
+        /// Crea una caja geográfica con los límites necesarios para consultar tráfico cercano.
+        /// </summary>
+        public GeoBoundingBox(
+            double minLatitude,
+            double minLongitude,
+            double maxLatitude,
+            double maxLongitude)
+        {
+            MinLatitude = minLatitude;
+            MinLongitude = minLongitude;
+            MaxLatitude = maxLatitude;
+            MaxLongitude = maxLongitude;
+        }
+
+        /// <summary>
+        /// Devuelve la bounding box con el formato de parámetros que necesita OpenSky.
+        /// Se usa InvariantCulture para asegurar decimales con punto.
+        /// </summary>
+        public string ToOpenSkyQuery()
+        {
+            return string.Format(
+                CultureInfo.InvariantCulture,
+                "lamin={0}&lomin={1}&lamax={2}&lomax={3}",
+                MinLatitude,
+                MinLongitude,
+                MaxLatitude,
+                MaxLongitude
+            );
+        }
+    }
+}

--- a/UnityProject/tfg/Assets/Scripts/Domain/Models/GeoBoundingBox.cs.meta
+++ b/UnityProject/tfg/Assets/Scripts/Domain/Models/GeoBoundingBox.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e60b8536dc930414397b6ac6599d4517
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/tfg/Assets/Scripts/Domain/Services.meta
+++ b/UnityProject/tfg/Assets/Scripts/Domain/Services.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3e23150daa4316a408532544ac3c7e98
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/tfg/Assets/Scripts/Domain/Services/BoundingBoxBuilder.cs
+++ b/UnityProject/tfg/Assets/Scripts/Domain/Services/BoundingBoxBuilder.cs
@@ -1,0 +1,86 @@
+/*
+ * BoundingBoxBuilder.cs
+ * ------------------------------------------------------------
+ * Este servicio calcula una caja geográfica alrededor de la posición
+ * propia del usuario/avión.
+ *
+ * Recibe una posición central (latitud y longitud) y un radio en kilómetros.
+ * A partir de esos datos genera los límites geográficos necesarios para
+ * consultar tráfico aéreo cercano en APIs externas como OpenSky.
+ *
+ * Se conecta con:
+ * - OwnshipGeoState: posición actual del usuario/avión.
+ * - GeoBoundingBox: resultado generado.
+ * - OpenSkyApiClient: futuro cliente que usará esta caja para consultar aeronaves.
+ */
+
+using System;
+using TFG.ARVisor.Domain.Models;
+
+namespace TFG.ARVisor.Domain.Services
+{
+    public static class BoundingBoxBuilder
+    {
+        private const double KilometersPerLatitudeDegree = 111.32;
+
+        /// <summary>
+        /// Crea una bounding box alrededor de la posición propia usando un radio en kilómetros.
+        /// </summary>
+        public static GeoBoundingBox FromOwnshipPosition(OwnshipGeoState ownshipState, double radiusKm)
+        {
+            if (ownshipState == null)
+            {
+                throw new ArgumentNullException(nameof(ownshipState));
+            }
+
+            return FromCoordinates(
+                ownshipState.Latitude,
+                ownshipState.Longitude,
+                radiusKm
+            );
+        }
+
+        /// <summary>
+        /// Calcula los límites geográficos mínimos y máximos alrededor de una latitud y longitud.
+        /// </summary>
+        public static GeoBoundingBox FromCoordinates(double latitude, double longitude, double radiusKm)
+        {
+            if (radiusKm <= 0)
+            {
+                throw new ArgumentException("El radio debe ser mayor que 0.", nameof(radiusKm));
+            }
+
+            double latitudeDelta = radiusKm / KilometersPerLatitudeDegree;
+
+            double latitudeRadians = latitude * Math.PI / 180.0;
+            double longitudeKmPerDegree = KilometersPerLatitudeDegree * Math.Cos(latitudeRadians);
+
+            if (Math.Abs(longitudeKmPerDegree) < 0.0001)
+            {
+                longitudeKmPerDegree = 0.0001;
+            }
+
+            double longitudeDelta = radiusKm / longitudeKmPerDegree;
+
+            double minLatitude = Clamp(latitude - latitudeDelta, -90.0, 90.0);
+            double maxLatitude = Clamp(latitude + latitudeDelta, -90.0, 90.0);
+            double minLongitude = Clamp(longitude - longitudeDelta, -180.0, 180.0);
+            double maxLongitude = Clamp(longitude + longitudeDelta, -180.0, 180.0);
+
+            return new GeoBoundingBox(
+                minLatitude,
+                minLongitude,
+                maxLatitude,
+                maxLongitude
+            );
+        }
+
+        /// <summary>
+        /// Limita un valor entre un mínimo y un máximo para evitar coordenadas fuera de rango.
+        /// </summary>
+        private static double Clamp(double value, double min, double max)
+        {
+            return Math.Max(min, Math.Min(max, value));
+        }
+    }
+}

--- a/UnityProject/tfg/Assets/Scripts/Domain/Services/BoundingBoxBuilder.cs.meta
+++ b/UnityProject/tfg/Assets/Scripts/Domain/Services/BoundingBoxBuilder.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2d7a6a7750b42d9409f67e959c970bf5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/tfg/Assets/Scripts/Infrastructure/ApiClients.meta
+++ b/UnityProject/tfg/Assets/Scripts/Infrastructure/ApiClients.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 38a55f430b301f141bbff2158212fa8a
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/tfg/Assets/Scripts/Infrastructure/ApiClients/OpenSkyApiClient.cs
+++ b/UnityProject/tfg/Assets/Scripts/Infrastructure/ApiClients/OpenSkyApiClient.cs
@@ -1,0 +1,193 @@
+/*
+ * OpenSkyApiClient.cs
+ * ------------------------------------------------------------
+ * Este script realiza la primera conexión real con la API de OpenSky.
+ *
+ * Su función es:
+ * 1. Obtener la posición actual del usuario/avión desde ExternalGpsProvider.
+ * 2. Calcular una bounding box alrededor de esa posición.
+ * 3. Construir la URL de consulta para OpenSky.
+ * 4. Realizar una petición HTTP real.
+ * 5. Mostrar en consola si se ha recibido JSON correctamente.
+ *
+ * De momento NO interpreta todavía todos los datos de las aeronaves.
+ * Este script solo valida que Unity puede conectarse a OpenSky y recibir
+ * tráfico aéreo actual dentro de la zona calculada.
+ *
+ * Se conecta con:
+ * - ExternalGpsProvider: obtiene la posición propia.
+ * - BoundingBoxBuilder: genera la zona de búsqueda.
+ * - GeoBoundingBox: contiene los límites de la consulta.
+ * - OpenSkyParser: se añadirá después para convertir el JSON en modelos propios.
+ */
+
+using System.Collections;
+using TFG.ARVisor.Domain.Models;
+using TFG.ARVisor.Domain.Services;
+using TFG.ARVisor.Infrastructure.Gps;
+using UnityEngine;
+using UnityEngine.Networking;
+
+namespace TFG.ARVisor.Infrastructure.ApiClients
+{
+    public class OpenSkyApiClient : MonoBehaviour
+    {
+        [Header("References")]
+        [SerializeField] private ExternalGpsProvider gpsProvider;
+
+        [Header("OpenSky Settings")]
+        [SerializeField] private string openSkyBaseUrl = "https://opensky-network.org/api/states/all";
+        [SerializeField] private double searchRadiusKm = 50.0;
+
+        [Header("Request Settings")]
+        [SerializeField] private float refreshSeconds = 15f;
+        [SerializeField] private int requestTimeoutSeconds = 10;
+
+        [Header("Debug Settings")]
+        [SerializeField] private bool logUrlToConsole = true;
+        [SerializeField] private bool logRawJsonPreview = true;
+
+        private Coroutine pollingCoroutine;
+
+        /// <summary>
+        /// Inicia el ciclo de consultas a OpenSky cuando arranca la escena.
+        /// </summary>
+        private void Start()
+        {
+            pollingCoroutine = StartCoroutine(PollOpenSkyLoop());
+        }
+
+        /// <summary>
+        /// Detiene el ciclo de consultas si el objeto se desactiva.
+        /// </summary>
+        private void OnDisable()
+        {
+            if (pollingCoroutine != null)
+            {
+                StopCoroutine(pollingCoroutine);
+                pollingCoroutine = null;
+            }
+        }
+
+        /// <summary>
+        /// Ejecuta consultas periódicas a OpenSky cada cierto número de segundos.
+        /// </summary>
+        private IEnumerator PollOpenSkyLoop()
+        {
+            while (true)
+            {
+                yield return FetchCurrentTraffic();
+                yield return new WaitForSeconds(refreshSeconds);
+            }
+        }
+
+        /// <summary>
+        /// Obtiene la posición propia, genera la bounding box y lanza la petición HTTP a OpenSky.
+        /// </summary>
+        private IEnumerator FetchCurrentTraffic()
+        {
+            if (gpsProvider == null)
+            {
+                Debug.LogWarning("OpenSkyApiClient: ExternalGpsProvider reference is missing.");
+                yield break;
+            }
+
+            OwnshipGeoState ownshipState = gpsProvider.CurrentState;
+
+            if (ownshipState == null)
+            {
+                Debug.LogWarning("OpenSkyApiClient: waiting for GPS position before requesting OpenSky.");
+                yield break;
+            }
+
+            GeoBoundingBox boundingBox = BoundingBoxBuilder.FromOwnshipPosition(
+                ownshipState,
+                searchRadiusKm
+            );
+
+            string requestUrl = $"{openSkyBaseUrl}?{boundingBox.ToOpenSkyQuery()}";
+
+            if (logUrlToConsole)
+            {
+                Debug.Log($"OpenSky request URL -> {requestUrl}");
+            }
+
+            using UnityWebRequest request = UnityWebRequest.Get(requestUrl);
+            request.timeout = requestTimeoutSeconds;
+
+            yield return request.SendWebRequest();
+
+            if (request.result != UnityWebRequest.Result.Success)
+            {
+                Debug.LogWarning($"OpenSky request failed: {request.responseCode} - {request.error}");
+                yield break;
+            }
+
+            string json = request.downloadHandler.text;
+
+            LogOpenSkyResponse(json);
+        }
+
+        /// <summary>
+        /// Muestra información básica del JSON recibido para confirmar que la conexión funciona.
+        /// </summary>
+        private void LogOpenSkyResponse(string json)
+        {
+            if (string.IsNullOrWhiteSpace(json))
+            {
+                Debug.LogWarning("OpenSky response is empty.");
+                return;
+            }
+
+            int estimatedAircraftCount = EstimateAircraftCount(json);
+
+            Debug.Log(
+                $"OpenSky response received. JSON length: {json.Length} chars. " +
+                $"Estimated aircraft count: {estimatedAircraftCount}"
+            );
+
+            if (logRawJsonPreview)
+            {
+                int previewLength = Mathf.Min(json.Length, 600);
+                Debug.Log($"OpenSky JSON preview -> {json.Substring(0, previewLength)}");
+            }
+        }
+
+        /// <summary>
+        /// Estima de forma provisional cuántas aeronaves vienen en el JSON.
+        /// El parser real se implementará después, porque OpenSky devuelve arrays internos complejos.
+        /// </summary>
+        private int EstimateAircraftCount(string json)
+        {
+            if (!json.Contains("\"states\"") || json.Contains("\"states\":null"))
+            {
+                return 0;
+            }
+
+            int statesStart = json.IndexOf("\"states\":[[", System.StringComparison.Ordinal);
+
+            if (statesStart < 0)
+            {
+                return 0;
+            }
+
+            int count = 1;
+            int searchIndex = statesStart;
+
+            while (true)
+            {
+                int nextIndex = json.IndexOf("],[", searchIndex, System.StringComparison.Ordinal);
+
+                if (nextIndex < 0)
+                {
+                    break;
+                }
+
+                count++;
+                searchIndex = nextIndex + 3;
+            }
+
+            return count;
+        }
+    }
+}

--- a/UnityProject/tfg/Assets/Scripts/Infrastructure/ApiClients/OpenSkyApiClient.cs.meta
+++ b/UnityProject/tfg/Assets/Scripts/Infrastructure/ApiClients/OpenSkyApiClient.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 584d61f93bd22a445b2e33f5373683c4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/tfg/Assets/Scripts/Infrastructure/ApiClients/OpenSkyQueryPreview.cs
+++ b/UnityProject/tfg/Assets/Scripts/Infrastructure/ApiClients/OpenSkyQueryPreview.cs
@@ -1,0 +1,99 @@
+/*
+ * OpenSkyQueryPreview.cs
+ * ------------------------------------------------------------
+ * Este script genera una URL de consulta para OpenSky a partir
+ * de la posición propia recibida por el ExternalGpsProvider.
+ *
+ * No realiza todavía la llamada real a la API. Su función es
+ * comprobar que el sistema ya puede:
+ *
+ * 1. Leer la posición actual del usuario/avión.
+ * 2. Calcular una bounding box alrededor de esa posición.
+ * 3. Construir una URL válida para consultar tráfico aéreo cercano.
+ *
+ * Se conecta con:
+ * - ExternalGpsProvider: obtiene la posición propia actual.
+ * - BoundingBoxBuilder: genera la caja geográfica de búsqueda.
+ * - GeoBoundingBox: almacena los límites geográficos.
+ *
+ * Este script es temporal/de apoyo y sirve para validar el flujo
+ * antes de implementar el cliente real de OpenSky.
+ */
+
+using TFG.ARVisor.Domain.Models;
+using TFG.ARVisor.Domain.Services;
+using TFG.ARVisor.Infrastructure.Gps;
+using UnityEngine;
+
+namespace TFG.ARVisor.Infrastructure.ApiClients
+{
+    public class OpenSkyQueryPreview : MonoBehaviour
+    {
+        [Header("References")]
+        [SerializeField] private ExternalGpsProvider gpsProvider;
+
+        [Header("OpenSky Settings")]
+        [SerializeField] private string openSkyBaseUrl = "https://opensky-network.org/api/states/all";
+        [SerializeField] private double searchRadiusKm = 50.0;
+
+        [Header("Debug Settings")]
+        [SerializeField] private float refreshSeconds = 3f;
+        [SerializeField] private bool logToConsole = true;
+
+        private float timer;
+
+        /// <summary>
+        /// Lanza una primera generación de URL al iniciar la escena.
+        /// </summary>
+        private void Start()
+        {
+            BuildAndLogOpenSkyUrl();
+        }
+
+        /// <summary>
+        /// Regenera la URL cada cierto tiempo para comprobar que se actualiza con la posición actual.
+        /// </summary>
+        private void Update()
+        {
+            timer += Time.deltaTime;
+
+            if (timer >= refreshSeconds)
+            {
+                timer = 0f;
+                BuildAndLogOpenSkyUrl();
+            }
+        }
+
+        /// <summary>
+        /// Obtiene la posición propia, calcula la bounding box y construye la URL de consulta para OpenSky.
+        /// </summary>
+        private void BuildAndLogOpenSkyUrl()
+        {
+            if (gpsProvider == null)
+            {
+                Debug.LogWarning("OpenSkyQueryPreview: ExternalGpsProvider reference is missing.");
+                return;
+            }
+
+            OwnshipGeoState ownshipState = gpsProvider.CurrentState;
+
+            if (ownshipState == null)
+            {
+                Debug.LogWarning("OpenSkyQueryPreview: waiting for GPS position...");
+                return;
+            }
+
+            GeoBoundingBox boundingBox = BoundingBoxBuilder.FromOwnshipPosition(
+                ownshipState,
+                searchRadiusKm
+            );
+
+            string queryUrl = $"{openSkyBaseUrl}?{boundingBox.ToOpenSkyQuery()}";
+
+            if (logToConsole)
+            {
+                Debug.Log($"OpenSky query URL -> {queryUrl}");
+            }
+        }
+    }
+}

--- a/UnityProject/tfg/Assets/Scripts/Infrastructure/ApiClients/OpenSkyQueryPreview.cs.meta
+++ b/UnityProject/tfg/Assets/Scripts/Infrastructure/ApiClients/OpenSkyQueryPreview.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f72782098afb26e48a2a02aa757f0ac0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Qué se ha hecho

- Se ha añadido el modelo `GeoBoundingBox` para representar zonas geográficas de búsqueda.
- Se ha creado `BoundingBoxBuilder` para generar una zona alrededor de la posición propia.
- Se ha generado una URL válida para consultar OpenSky usando `lamin`, `lomin`, `lamax` y `lomax`.
- Se ha creado `OpenSkyApiClient` para realizar la primera petición real a la API.
- Se ha validado que Unity recibe JSON real de OpenSky.
- Se ha corregido el formato decimal para que OpenSky reciba números con punto decimal.

## Pruebas realizadas

- Probado con GPS real recibido desde smartphone.
- Verificada generación de bounding box desde la posición actual.
- Verificada petición real a OpenSky.
- Verificada respuesta JSON en consola de Unity.
- Verificado recuento estimado de aeronaves recibidas.

## Próximo paso

- Crear el parser de OpenSky para convertir el JSON recibido en modelos internos de aeronaves.