### PR TITLE
Add initial risk engine

### DIFF
--- a/UnityProject/tfg/Assets/Scripts/Domain/Models/RiskAssessment.cs
+++ b/UnityProject/tfg/Assets/Scripts/Domain/Models/RiskAssessment.cs
@@ -1,0 +1,50 @@
+/*
+ * RiskAssessment.cs
+ * ------------------------------------------------------------
+ * Este modelo representa el resultado de analizar el riesgo asociado
+ * al tráfico aéreo cercano.
+ *
+ * Su función es agrupar en un solo objeto:
+ * - el nivel de riesgo calculado,
+ * - el mensaje de alerta asociado,
+ * - la aeronave más relevante,
+ * - la distancia de la aeronave más cercana,
+ * - la diferencia de altitud si está disponible.
+ *
+ * Se conecta con:
+ * - RiskEngine: genera este resultado a partir de las aeronaves cercanas.
+ * - OpenSkyApiClient: usará este resultado para actualizar el HUD.
+ * - HudController: mostrará el nivel de riesgo y el mensaje de alerta.
+ */
+
+namespace TFG.ARVisor.Domain.Models
+{
+    public class RiskAssessment
+    {
+        public RiskLevel RiskLevel { get; }
+        public string AlertMessage { get; }
+        public AircraftGeoState MostRelevantAircraft { get; }
+        public double? NearestDistanceKm { get; }
+        public double? AltitudeDifferenceMeters { get; }
+        public int AircraftCount { get; }
+
+        /// <summary>
+        /// Crea el resultado del análisis de riesgo calculado para el tráfico cercano.
+        /// </summary>
+        public RiskAssessment(
+            RiskLevel riskLevel,
+            string alertMessage,
+            AircraftGeoState mostRelevantAircraft,
+            double? nearestDistanceKm,
+            double? altitudeDifferenceMeters,
+            int aircraftCount)
+        {
+            RiskLevel = riskLevel;
+            AlertMessage = alertMessage;
+            MostRelevantAircraft = mostRelevantAircraft;
+            NearestDistanceKm = nearestDistanceKm;
+            AltitudeDifferenceMeters = altitudeDifferenceMeters;
+            AircraftCount = aircraftCount;
+        }
+    }
+}

--- a/UnityProject/tfg/Assets/Scripts/Domain/Models/RiskAssessment.cs.meta
+++ b/UnityProject/tfg/Assets/Scripts/Domain/Models/RiskAssessment.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6ff81fea55877cc46b0ce1699a226334
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/tfg/Assets/Scripts/Domain/Services/RiskEngine.cs
+++ b/UnityProject/tfg/Assets/Scripts/Domain/Services/RiskEngine.cs
@@ -1,0 +1,190 @@
+/*
+ * RiskEngine.cs
+ * ------------------------------------------------------------
+ * Este servicio calcula un primer nivel de riesgo a partir de las
+ * aeronaves cercanas recibidas desde OpenSky.
+ *
+ * Funcionamiento general:
+ * 1. Recibe la posición propia del usuario/avión.
+ * 2. Recibe la lista de aeronaves ya filtradas por distancia.
+ * 3. Busca la aeronave más cercana.
+ * 4. Calcula la distancia horizontal.
+ * 5. Si hay altitud fiable, también calcula diferencia vertical.
+ * 6. Devuelve un RiskAssessment con nivel LOW, MEDIUM o HIGH.
+ *
+ * Este cálculo es una primera versión para el prototipo. Más adelante
+ * se podrá mejorar teniendo en cuenta rumbo, velocidad relativa y
+ * orientación del visor.
+ *
+ * Se conecta con:
+ * - OwnshipGeoState: posición propia.
+ * - AircraftGeoState: aeronaves cercanas.
+ * - GeoDistanceCalculator: cálculo de distancia horizontal.
+ * - OpenSkyApiClient: usará este motor para actualizar el HUD.
+ */
+
+using System;
+using System.Collections.Generic;
+using TFG.ARVisor.Domain.Models;
+
+namespace TFG.ARVisor.Domain.Services
+{
+    public static class RiskEngine
+    {
+        private const double HighRiskDistance2D = 10.0;
+        private const double MediumRiskDistance2D = 30.0;
+
+        private const double HighRiskDistance3D = 10.0;
+        private const double MediumRiskDistance3D = 30.0;
+
+        private const double HighRiskAltitudeDifferenceMeters = 300.0;
+        private const double MediumRiskAltitudeDifferenceMeters = 700.0;
+
+        /// <summary>
+        /// Evalúa el riesgo del tráfico cercano respecto a la posición propia.
+        /// </summary>
+        public static RiskAssessment Evaluate(
+            OwnshipGeoState ownshipState,
+            List<AircraftGeoState> aircraft)
+        {
+            if (ownshipState == null)
+            {
+                throw new ArgumentNullException(nameof(ownshipState));
+            }
+
+            if (aircraft == null || aircraft.Count == 0)
+            {
+                return new RiskAssessment(
+                    RiskLevel.Low,
+                    "NO ALERTS",
+                    null,
+                    null,
+                    null,
+                    0
+                );
+            }
+
+            AircraftGeoState nearestAircraft = null;
+            double nearestDistanceKm = double.MaxValue;
+            double? nearestAltitudeDifference = null;
+
+            foreach (AircraftGeoState item in aircraft)
+            {
+                double distanceKm = GeoDistanceCalculator.DistanceKm(ownshipState, item);
+
+                if (distanceKm < nearestDistanceKm)
+                {
+                    nearestDistanceKm = distanceKm;
+                    nearestAircraft = item;
+                    nearestAltitudeDifference = CalculateAltitudeDifference(ownshipState, item);
+                }
+            }
+
+            RiskLevel riskLevel = CalculateRiskLevel(
+                ownshipState,
+                nearestDistanceKm,
+                nearestAltitudeDifference
+            );
+
+            string alertMessage = GetAlertMessage(riskLevel);
+
+            return new RiskAssessment(
+                riskLevel,
+                alertMessage,
+                nearestAircraft,
+                nearestDistanceKm,
+                nearestAltitudeDifference,
+                aircraft.Count
+            );
+        }
+
+        /// <summary>
+        /// Calcula la diferencia absoluta de altitud entre la posición propia y una aeronave.
+        /// </summary>
+        private static double? CalculateAltitudeDifference(
+            OwnshipGeoState ownshipState,
+            AircraftGeoState aircraft)
+        {
+            if (!ownshipState.AltitudeMeters.HasValue || !aircraft.AltitudeMeters.HasValue)
+            {
+                return null;
+            }
+
+            return Math.Abs(ownshipState.AltitudeMeters.Value - aircraft.AltitudeMeters.Value);
+        }
+
+        /// <summary>
+        /// Calcula el nivel de riesgo usando distancia horizontal y, si es fiable, diferencia de altitud.
+        /// </summary>
+        private static RiskLevel CalculateRiskLevel(
+            OwnshipGeoState ownshipState,
+            double nearestDistanceKm,
+            double? altitudeDifferenceMeters)
+        {
+            if (ownshipState.Mode == OwnshipMode.Mode3D && altitudeDifferenceMeters.HasValue)
+            {
+                return Calculate3DRisk(nearestDistanceKm, altitudeDifferenceMeters.Value);
+            }
+
+            return Calculate2DRisk(nearestDistanceKm);
+        }
+
+        /// <summary>
+        /// Calcula riesgo en modo 2D cuando no hay altitud fiable.
+        /// </summary>
+        private static RiskLevel Calculate2DRisk(double distanceKm)
+        {
+            if (distanceKm <= HighRiskDistance2D)
+            {
+                return RiskLevel.High;
+            }
+
+            if (distanceKm <= MediumRiskDistance2D)
+            {
+                return RiskLevel.Medium;
+            }
+
+            return RiskLevel.Low;
+        }
+
+        /// <summary>
+        /// Calcula riesgo en modo 3D usando distancia horizontal y separación vertical.
+        /// </summary>
+        private static RiskLevel Calculate3DRisk(
+            double distanceKm,
+            double altitudeDifferenceMeters)
+        {
+            if (distanceKm <= HighRiskDistance3D &&
+                altitudeDifferenceMeters <= HighRiskAltitudeDifferenceMeters)
+            {
+                return RiskLevel.High;
+            }
+
+            if (distanceKm <= MediumRiskDistance3D &&
+                altitudeDifferenceMeters <= MediumRiskAltitudeDifferenceMeters)
+            {
+                return RiskLevel.Medium;
+            }
+
+            return RiskLevel.Low;
+        }
+
+        /// <summary>
+        /// Devuelve el mensaje de alerta asociado al nivel de riesgo calculado.
+        /// </summary>
+        private static string GetAlertMessage(RiskLevel riskLevel)
+        {
+            switch (riskLevel)
+            {
+                case RiskLevel.High:
+                    return "COLLISION RISK";
+
+                case RiskLevel.Medium:
+                    return "TRAFFIC ADVISORY";
+
+                default:
+                    return "NO ALERTS";
+            }
+        }
+    }
+}

--- a/UnityProject/tfg/Assets/Scripts/Domain/Services/RiskEngine.cs.meta
+++ b/UnityProject/tfg/Assets/Scripts/Domain/Services/RiskEngine.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 61c3e54b3249bd74a8872073d2c76bb5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/tfg/Assets/Scripts/Infrastructure/ApiClients/OpenSkyApiClient.cs
+++ b/UnityProject/tfg/Assets/Scripts/Infrastructure/ApiClients/OpenSkyApiClient.cs
@@ -120,10 +120,19 @@ namespace TFG.ARVisor.Infrastructure.ApiClients
 
             yield return request.SendWebRequest();
 
-            if (request.result != UnityWebRequest.Result.Success)
+           if (request.result != UnityWebRequest.Result.Success)
             {
                 Debug.LogWarning($"OpenSky request failed: {request.responseCode} - {request.error}");
-                UpdateHudWithTraffic(0, "--");
+
+                UpdateHudWithRisk(new RiskAssessment(
+                    RiskLevel.Low,
+                    "NO ALERTS",
+                    null,
+                    null,
+                    null,
+                    0
+                ));
+
                 yield break;
             }
 
@@ -133,15 +142,22 @@ namespace TFG.ARVisor.Infrastructure.ApiClients
         }
 
         /// <summary>
-        /// Procesa el JSON recibido desde OpenSky, convierte las aeronaves a modelos internos
-        /// y actualiza el HUD con el número de aeronaves reales y la distancia de la más cercana.
+        /// Procesa el JSON recibido desde OpenSky, convierte las aeronaves a modelos internos,
+        /// filtra las aeronaves por distancia real y calcula el riesgo inicial para actualizar el HUD.
         /// </summary>
         private void ProcessOpenSkyResponse(string json, OwnshipGeoState ownshipState)
         {
             if (string.IsNullOrWhiteSpace(json))
             {
                 Debug.LogWarning("OpenSky response is empty.");
-                UpdateHudWithTraffic(0, "--");
+                UpdateHudWithRisk(new RiskAssessment(
+                    RiskLevel.Low,
+                    "NO ALERTS",
+                    null,
+                    null,
+                    null,
+                    0
+                ));
                 return;
             }
 
@@ -158,13 +174,12 @@ namespace TFG.ARVisor.Infrastructure.ApiClients
                 $"Inside {searchRadiusKm:0} KM: {nearbyAircraft.Count}"
             );
 
-            double? nearestDistanceKm = GetNearestAircraftDistanceKm(ownshipState, nearbyAircraft);
+            RiskAssessment riskAssessment = RiskEngine.Evaluate(
+                ownshipState,
+                nearbyAircraft
+            );
 
-            string nearestDistanceText = nearestDistanceKm.HasValue
-                ? $"{nearestDistanceKm.Value:0.0} KM"
-                : "--";
-
-            UpdateHudWithTraffic(nearbyAircraft.Count, nearestDistanceText);
+            UpdateHudWithRisk(riskAssessment);
 
             LogAircraftList(ownshipState, nearbyAircraft);
 
@@ -229,23 +244,35 @@ namespace TFG.ARVisor.Infrastructure.ApiClients
         }
 
         /// <summary>
-        /// Actualiza el HUD con el resumen básico de tráfico real recibido desde OpenSky.
+        /// Actualiza el HUD con el resumen de tráfico real y el nivel de riesgo calculado.
         /// </summary>
-        private void UpdateHudWithTraffic(int aircraftCount, string nearestDistanceText)
+        private void UpdateHudWithRisk(RiskAssessment riskAssessment)
         {
-            if (hudController == null)
+            if (hudController == null || riskAssessment == null)
             {
                 return;
             }
 
+            string nearestDistanceText = riskAssessment.NearestDistanceKm.HasValue
+                ? $"{riskAssessment.NearestDistanceKm.Value:0.0} KM"
+                : "--";
+
             TrafficSnapshot snapshot = new TrafficSnapshot(
-                nearbyAircraft: aircraftCount,
+                nearbyAircraft: riskAssessment.AircraftCount,
                 nearestDistance: nearestDistanceText,
-                riskLevel: RiskLevel.Low,
-                alertMessage: aircraftCount > 0 ? "TRAFFIC DETECTED" : "NO ALERTS"
+                riskLevel: riskAssessment.RiskLevel,
+                alertMessage: riskAssessment.AlertMessage
             );
 
             hudController.RenderTraffic(snapshot);
+
+            Debug.Log(
+                $"Risk assessment -> " +
+                $"Aircraft: {riskAssessment.AircraftCount}, " +
+                $"Nearest: {nearestDistanceText}, " +
+                $"Risk: {riskAssessment.RiskLevel}, " +
+                $"Alert: {riskAssessment.AlertMessage}"
+            );
         }
     }
 }


### PR DESCRIPTION
## Qué se ha hecho

- Se ha creado el modelo `RiskAssessment`.
- Se ha implementado `RiskEngine` para calcular riesgo inicial.
- Se ha conectado el cálculo de riesgo con `OpenSkyApiClient`.
- El HUD ya puede mostrar riesgo `LOW`, `MEDIUM` o `HIGH`.
- Se ha añadido mensaje de alerta según el nivel de riesgo:
  - `NO ALERTS`
  - `TRAFFIC ADVISORY`
  - `COLLISION RISK`

## Pruebas realizadas

- Probado con tráfico real recibido desde OpenSky.
- Verificado cálculo de riesgo bajo con aeronaves lejanas.
- Realizada prueba controlada modificando umbrales temporalmente.
- Verificado que el HUD muestra `RISK MEDIUM`.
- Verificado que el HUD muestra `RISK HIGH`.
- Restaurados los umbrales reales después de la prueba.

## Próximo paso

- Mejorar el cálculo de riesgo teniendo en cuenta altitud, rumbo, aproximación y priorización de aeronaves.