### PR TITLE
Improve HUD visual risk alerts

### DIFF
--- a/UnityProject/tfg/Assets/MRTemplateAssets/Prefabs/MRInteractionSetup.prefab
+++ b/UnityProject/tfg/Assets/MRTemplateAssets/Prefabs/MRInteractionSetup.prefab
@@ -24,6 +24,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 464134550068363535}
+  serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0.099137, y: -0.0012719631, z: 0.047823}
   m_LocalScale: {x: 1, y: 1, z: 1}
@@ -31,7 +32,6 @@ Transform:
   m_Children:
   - {fileID: 8728449774652382186}
   m_Father: {fileID: 537582244687957546}
-  m_RootOrder: -2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &627603378869086806
 MonoBehaviour:
@@ -126,13 +126,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 986987362910788458}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0.025}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 592917367565222513}
-  m_RootOrder: -2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!136 &9026698599295767393
 CapsuleCollider:
@@ -181,13 +181,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1266712985055414496}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0.025}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 4391824671712824351}
-  m_RootOrder: -2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!136 &406795562156099220
 CapsuleCollider:
@@ -236,6 +236,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1297405824071334540}
+  serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0.099137, y: -0.0012719631, z: 0.047823}
   m_LocalScale: {x: 1, y: 1, z: 1}
@@ -243,7 +244,6 @@ Transform:
   m_Children:
   - {fileID: 1885025210676732134}
   m_Father: {fileID: 104957837394448809}
-  m_RootOrder: -2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &4578511197687121291
 MonoBehaviour:
@@ -339,13 +339,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1575009680292340977}
+  serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 6391579207171690961}
-  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &9141707819853251315
 MonoBehaviour:
@@ -425,13 +425,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1679826743566741650}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0.025}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 6377634905225778432}
-  m_RootOrder: -2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!136 &7890318252006486000
 CapsuleCollider:
@@ -480,13 +480,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2429007254548286490}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0.025}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 2456832866133269792}
-  m_RootOrder: -2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!136 &7663891498497803186
 CapsuleCollider:
@@ -535,13 +535,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2591788395326865968}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 6391579207171690961}
-  m_RootOrder: -2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &9177915868812651432
 MonoBehaviour:
@@ -606,13 +606,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2662485833752745289}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0.0533}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 5623248194768087441}
-  m_RootOrder: -2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!65 &3660509240678822123
 BoxCollider:
@@ -659,13 +659,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 3018255141171309918}
+  serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 6391579207171690961}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &6917046410410406575
 MonoBehaviour:
@@ -706,13 +706,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 3155041718856601879}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0.025}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 6196183587827149803}
-  m_RootOrder: -2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!136 &2412228288700569403
 CapsuleCollider:
@@ -761,13 +761,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 3486836159582563889}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0.025}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 5219202664705858890}
-  m_RootOrder: -2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!136 &1714631094739956761
 CapsuleCollider:
@@ -815,6 +815,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 3540285630127457094}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
@@ -828,7 +829,6 @@ Transform:
   - {fileID: 7419610871887886442}
   - {fileID: 3918692831784067096}
   m_Father: {fileID: 0}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &4009614286898648619
 GameObject:
@@ -854,13 +854,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 4009614286898648619}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0.025}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 5725254047580564444}
-  m_RootOrder: -2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!136 &259679506797978743
 CapsuleCollider:
@@ -909,13 +909,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 4142027224488549785}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0.025}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 7534381850386869571}
-  m_RootOrder: -2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!136 &7994533889114118147
 CapsuleCollider:
@@ -964,13 +964,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 5543268644248908676}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0.0533}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 4438111494233584997}
-  m_RootOrder: -2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!65 &8331549380546554295
 BoxCollider:
@@ -1017,13 +1017,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 5826210186024803414}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0.025}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 5945580547228731966}
-  m_RootOrder: -2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!136 &1205929309213748077
 CapsuleCollider:
@@ -1072,13 +1072,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 5921622752412215052}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0.025}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 4499886206833588671}
-  m_RootOrder: -2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!136 &3193499088491952753
 CapsuleCollider:
@@ -1127,13 +1127,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 5927766569307347129}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0.025}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1362172527046361305}
-  m_RootOrder: -2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!136 &7428596207706515195
 CapsuleCollider:
@@ -1182,13 +1182,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 6355484307165517602}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0.025}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 407888478862405868}
-  m_RootOrder: -2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!136 &4114159750782180048
 CapsuleCollider:
@@ -1238,13 +1238,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 6383841202730774034}
+  serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 6391579207171690961}
-  m_RootOrder: -2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &2970068989662574442
 MonoBehaviour:
@@ -1309,13 +1309,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 6660900155203182598}
+  serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 6391579207171690961}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &1228200670664215197
 MonoBehaviour:
@@ -1355,13 +1355,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 7062434211270712698}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0.025}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1480276118072738339}
-  m_RootOrder: -2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!136 &8504685721728230666
 CapsuleCollider:
@@ -1410,13 +1410,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 8541496619944040517}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0.025}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 7593440153185980844}
-  m_RootOrder: -2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!136 &3322437812292955453
 CapsuleCollider:
@@ -1467,13 +1467,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 8993040715512175147}
+  serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 6391579207171690961}
-  m_RootOrder: -2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &654720365977580427
 MonoBehaviour:
@@ -1829,6 +1829,10 @@ PrefabInstance:
       propertyPath: m_ModelPrefab
       value: 
       objectReference: {fileID: 665267158092037711, guid: e8fb48b2097a4fe4c9bad4f438c1eae2, type: 3}
+    - target: {fileID: 657184242539281764, guid: d6878e1999eb4b44a9f5a263af86c185, type: 3}
+      propertyPath: m_Parameters.widthMultiplier
+      value: 0.01
+      objectReference: {fileID: 0}
     - target: {fileID: 657184242539281767, guid: d6878e1999eb4b44a9f5a263af86c185, type: 3}
       propertyPath: m_IsActive
       value: 0
@@ -1988,6 +1992,10 @@ PrefabInstance:
     - target: {fileID: 2942706408635925570, guid: d6878e1999eb4b44a9f5a263af86c185, type: 3}
       propertyPath: m_SelectEntered.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
       value: UnityEngine.Object, UnityEngine
+      objectReference: {fileID: 0}
+    - target: {fileID: 2945826935290517885, guid: d6878e1999eb4b44a9f5a263af86c185, type: 3}
+      propertyPath: m_Parameters.widthMultiplier
+      value: 0.01
       objectReference: {fileID: 0}
     - target: {fileID: 2945826935290517886, guid: d6878e1999eb4b44a9f5a263af86c185, type: 3}
       propertyPath: m_IsActive

--- a/UnityProject/tfg/Assets/Scenes/MainScene.unity
+++ b/UnityProject/tfg/Assets/Scenes/MainScene.unity
@@ -1223,7 +1223,7 @@ MonoBehaviour:
   hudController: {fileID: 392099730}
   openSkyBaseUrl: https://opensky-network.org/api/states/all
   searchRadiusKm: 100
-  refreshSeconds: 120
+  refreshSeconds: 20
   requestTimeoutSeconds: 10
   logUrlToConsole: 1
   logRawJsonPreview: 1
@@ -1250,6 +1250,34 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 658929633056428010, guid: 86a5bf68cb51f4e44bd3893bd22a2ba7, type: 3}
+      propertyPath: m_LeftHand
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 658929633056428010, guid: 86a5bf68cb51f4e44bd3893bd22a2ba7, type: 3}
+      propertyPath: m_RightHand
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 658929633056428010, guid: 86a5bf68cb51f4e44bd3893bd22a2ba7, type: 3}
+      propertyPath: m_LeftController
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 658929633056428010, guid: 86a5bf68cb51f4e44bd3893bd22a2ba7, type: 3}
+      propertyPath: m_RightController
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 2028050440749766330, guid: 86a5bf68cb51f4e44bd3893bd22a2ba7, type: 3}
+      propertyPath: m_GazeInteractor
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 2028050440749766330, guid: 86a5bf68cb51f4e44bd3893bd22a2ba7, type: 3}
+      propertyPath: m_RayInteractors.Array.data[1].m_Interactor
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 2028050440749766330, guid: 86a5bf68cb51f4e44bd3893bd22a2ba7, type: 3}
+      propertyPath: m_RayInteractors.Array.data[3].m_Interactor
+      value: 
+      objectReference: {fileID: 0}
     - target: {fileID: 2605247947712448002, guid: 86a5bf68cb51f4e44bd3893bd22a2ba7, type: 3}
       propertyPath: m_Target
       value: 
@@ -1310,6 +1338,10 @@ PrefabInstance:
       propertyPath: m_AimTargetObject
       value: 
       objectReference: {fileID: 0}
+    - target: {fileID: 5029185155966391258, guid: 86a5bf68cb51f4e44bd3893bd22a2ba7, type: 3}
+      propertyPath: m_ControllerTransform
+      value: 
+      objectReference: {fileID: 0}
     - target: {fileID: 6391579207171690961, guid: 86a5bf68cb51f4e44bd3893bd22a2ba7, type: 3}
       propertyPath: m_RootOrder
       value: 2
@@ -1353,6 +1385,18 @@ PrefabInstance:
     - target: {fileID: 6391579207171690961, guid: 86a5bf68cb51f4e44bd3893bd22a2ba7, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6619657543770095898, guid: 86a5bf68cb51f4e44bd3893bd22a2ba7, type: 3}
+      propertyPath: m_LeftControllerTransform
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 6619657543770095898, guid: 86a5bf68cb51f4e44bd3893bd22a2ba7, type: 3}
+      propertyPath: m_RightControllerTransform
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 7013250357697848877, guid: 86a5bf68cb51f4e44bd3893bd22a2ba7, type: 3}
+      propertyPath: m_ControllerTransform
+      value: 
       objectReference: {fileID: 0}
     - target: {fileID: 7389883658536980360, guid: 86a5bf68cb51f4e44bd3893bd22a2ba7, type: 3}
       propertyPath: m_MetaQuestLeftHandMesh

--- a/UnityProject/tfg/Assets/Scripts/Infrastructure/ApiClients/OpenSkyApiClient.cs
+++ b/UnityProject/tfg/Assets/Scripts/Infrastructure/ApiClients/OpenSkyApiClient.cs
@@ -288,47 +288,56 @@ namespace TFG.ARVisor.Infrastructure.ApiClients
         }
 
         /// <summary>
-        /// Devuelve el callsign de la aeronave relevante o su identificador si no hay callsign disponible.
-        /// </summary>
-        private string GetAircraftCallsign(AircraftGeoState aircraft)
-        {
-            if (aircraft == null)
-            {
-                return "";
-            }
-
-            if (!string.IsNullOrWhiteSpace(aircraft.Callsign))
-            {
-                return aircraft.Callsign;
-            }
-
-            return aircraft.Id;
-        }
-
-        /// <summary>
-        /// Formatea la altitud de la aeronave para mostrarla en el HUD.
-        /// </summary>
-        private string FormatAltitude(AircraftGeoState aircraft)
-        {
-            if (aircraft == null || !aircraft.AltitudeMeters.HasValue)
-            {
-                return "--";
-            }
-
-            return $"{aircraft.AltitudeMeters.Value:0} M";
-        }
-
-        /// <summary>
-        /// Formatea el rumbo de la aeronave para mostrarlo en el HUD.
-        /// </summary>
-        private string FormatHeading(AircraftGeoState aircraft)
-        {
-            if (aircraft == null || !aircraft.HeadingDegrees.HasValue)
-            {
-                return "--";
-            }
-
-            return $"{aircraft.HeadingDegrees.Value:0}°";
-        }
+/// Devuelve el callsign de la aeronave relevante.
+/// Si no existe callsign, usa el identificador de la aeronave.
+/// Si tampoco existe identificador, muestra UNKNOWN.
+/// </summary>
+private string GetAircraftCallsign(AircraftGeoState aircraft)
+{
+    if (aircraft == null)
+    {
+        return "";
     }
+
+    if (!string.IsNullOrWhiteSpace(aircraft.Callsign))
+    {
+        return aircraft.Callsign.Trim();
+    }
+
+    if (!string.IsNullOrWhiteSpace(aircraft.Id))
+    {
+        return aircraft.Id.Trim().ToUpper();
+    }
+
+    return "UNKNOWN";
+}
+
+ /// <summary>
+/// Formatea la altitud de la aeronave para mostrarla en el HUD.
+/// Si la altitud no está disponible, muestra "--".
+/// </summary>
+private string FormatAltitude(AircraftGeoState aircraft)
+{
+    if (aircraft == null || !aircraft.AltitudeMeters.HasValue)
+    {
+        return "--";
+    }
+
+    return $"{aircraft.AltitudeMeters.Value:0} M";
+}
+
+       /// <summary>
+/// Formatea el rumbo de la aeronave para mostrarlo en el HUD.
+/// Si el rumbo no está disponible, muestra "--".
+/// </summary>
+private string FormatHeading(AircraftGeoState aircraft)
+{
+    if (aircraft == null || !aircraft.HeadingDegrees.HasValue)
+    {
+        return "--";
+    }
+
+    return $"{aircraft.HeadingDegrees.Value:0}°";
+}
+}
 }

--- a/UnityProject/tfg/Assets/Scripts/Presentation/HUD/HudController.cs
+++ b/UnityProject/tfg/Assets/Scripts/Presentation/HUD/HudController.cs
@@ -65,25 +65,26 @@ namespace TFG.ARVisor.Presentation.HUD
         }
 
         /// <summary>
-        /// Actualiza el panel derecho del HUD con el resumen de tráfico y la aeronave más relevante.
+        /// Actualiza el panel derecho del HUD con el resumen de tráfico, la aeronave relevante
+        /// y una diferenciación visual según el nivel de riesgo calculado.
         /// </summary>
         public void RenderTraffic(TrafficSnapshot snapshot)
         {
             if (trafficText != null)
             {
                 trafficText.text = BuildTrafficText(snapshot);
+                trafficText.color = GetRiskColor(snapshot != null ? snapshot.RiskLevel : RiskLevel.Low);
             }
 
-            RenderAlert(snapshot.AlertMessage, snapshot.RiskLevel);
+            if (snapshot != null)
+            {
+                RenderAlert(snapshot.AlertMessage, snapshot.RiskLevel);
+            }
         }
 
         /// <summary>
-        /// Construye el texto del panel derecho dependiendo de si existe o no una aeronave relevante.
-        /// </summary>
-        /// <summary>
         /// Construye el texto del panel derecho del HUD.
-        /// Si existe una aeronave relevante, muestra sus datos de forma prioritaria.
-        /// Si no existe, muestra un estado limpio de ausencia de tráfico relevante.
+        /// Destaca la aeronave relevante y adapta el texto al nivel de riesgo.
         /// </summary>
         private string BuildTrafficText(TrafficSnapshot snapshot)
         {
@@ -97,6 +98,8 @@ namespace TFG.ARVisor.Presentation.HUD
                     "RISK  --";
             }
 
+            string riskLabel = GetRiskLabel(snapshot.RiskLevel);
+
             if (HasRelevantAircraft(snapshot))
             {
                 return
@@ -106,7 +109,7 @@ namespace TFG.ARVisor.Presentation.HUD
                     $"ALT   {snapshot.RelevantAltitude}\n" +
                     $"HDG   {snapshot.RelevantHeading}\n\n" +
                     $"TRAF  {snapshot.NearbyAircraft}\n" +
-                    $"RISK  {FormatRisk(snapshot.RiskLevel)}";
+                    $"RISK  {riskLabel}";
             }
 
             return
@@ -114,7 +117,7 @@ namespace TFG.ARVisor.Presentation.HUD
                 "NO TARGET\n\n" +
                 $"TRAF  {snapshot.NearbyAircraft}\n" +
                 $"NEAR  {snapshot.NearestDistance}\n" +
-                $"RISK  {FormatRisk(snapshot.RiskLevel)}";
+                $"RISK  {riskLabel}";
         }
 
         /// <summary>
@@ -127,7 +130,7 @@ namespace TFG.ARVisor.Presentation.HUD
         }
 
         /// <summary>
-        /// Actualiza el mensaje superior de alerta y cambia su color según el nivel de riesgo.
+        /// Actualiza el mensaje superior de alerta y lo hace más visible según el nivel de riesgo.
         /// </summary>
         private void RenderAlert(string message, RiskLevel riskLevel)
         {
@@ -136,21 +139,57 @@ namespace TFG.ARVisor.Presentation.HUD
                 return;
             }
 
-            alertText.text = message;
-
             switch (riskLevel)
             {
-                case RiskLevel.Low:
-                    alertText.color = new Color(0.85f, 0.85f, 0.85f);
+                case RiskLevel.High:
+                    alertText.text = $"!!! {message} !!!";
                     break;
 
                 case RiskLevel.Medium:
-                    alertText.color = new Color(1f, 0.8f, 0.2f);
+                    alertText.text = $"-- {message} --";
                     break;
 
-                case RiskLevel.High:
-                    alertText.color = new Color(1f, 0.2f, 0.2f);
+                default:
+                    alertText.text = message;
                     break;
+            }
+
+            alertText.color = GetRiskColor(riskLevel);
+        }
+
+        /// <summary>
+        /// Devuelve el color visual asociado a cada nivel de riesgo.
+        /// </summary>
+        private Color GetRiskColor(RiskLevel riskLevel)
+        {
+            switch (riskLevel)
+            {
+                case RiskLevel.High:
+                    return new Color(1f, 0.2f, 0.2f);
+
+                case RiskLevel.Medium:
+                    return new Color(1f, 0.8f, 0.2f);
+
+                default:
+                    return new Color(0.9f, 0.9f, 0.9f);
+            }
+        }
+
+        /// <summary>
+        /// Devuelve el texto corto que representa el nivel de riesgo en el HUD.
+        /// </summary>
+        private string GetRiskLabel(RiskLevel riskLevel)
+        {
+            switch (riskLevel)
+            {
+                case RiskLevel.High:
+                    return "HIGH";
+
+                case RiskLevel.Medium:
+                    return "MED";
+
+                default:
+                    return "LOW";
             }
         }
 


### PR DESCRIPTION
## Qué se ha hecho

- Se ha mejorado la presentación visual del HUD.
- Se ha reorganizado el panel derecho para mostrar mejor la aeronave relevante.
- Se ha añadido diferenciación visual del riesgo:
  - LOW
  - MEDIUM
  - HIGH
- Se ha coloreado únicamente el nivel de riesgo para evitar saturar el panel.
- Se ha mejorado el mensaje superior de alerta según el nivel de riesgo.
- Se ha controlado la visualización de valores ausentes como callsign, altitud o rumbo.

## Pruebas realizadas

- Verificado que el panel derecho muestra la aeronave relevante.
- Verificado que el HUD muestra correctamente LOW, MEDIUM y HIGH.
- Verificado mediante prueba controlada que las alertas cambian según el nivel de riesgo.
- Verificado que el proyecto compila correctamente.
- Restaurados los umbrales reales después de las pruebas.

## Próximo paso

- Comenzar la visualización AR básica de aeronaves cercanas.