### PR TITLE
Add controlled conflict test scenarios

### DIFF
--- a/UnityProject/tfg/Assets/Scenes/MainScene.unity
+++ b/UnityProject/tfg/Assets/Scenes/MainScene.unity
@@ -238,7 +238,7 @@ MonoBehaviour:
   gpsEndpointUrl: http://127.0.0.1:5000/latest
   refreshSeconds: 1
   requestTimeoutSeconds: 2
-  logGpsToConsole: 1
+  logGpsToConsole: 0
 --- !u!4 &294844436
 Transform:
   m_ObjectHideFlags: 0
@@ -1322,6 +1322,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   gpsProvider: {fileID: 294844435}
+  logAircraftListToConsole: 0
   hudController: {fileID: 392099730}
   headsetOrientationProvider: {fileID: 320596662}
   motionEstimator: {fileID: 299444311}
@@ -1333,8 +1334,10 @@ MonoBehaviour:
   requestTimeoutSeconds: 10
   hudTargetRefreshSeconds: 1
   logHudTargetRefresh: 0
-  logUrlToConsole: 1
-  logRawJsonPreview: 1
+  logUrlToConsole: 0
+  logRawJsonPreview: 0
+  logConflictPredictionToConsole: 1
+  conflictLogIntervalSeconds: 3
 --- !u!4 &2058325481
 Transform:
   m_ObjectHideFlags: 0

--- a/UnityProject/tfg/Assets/Scripts/Domain/Models/ConflictTestScenarioType.cs
+++ b/UnityProject/tfg/Assets/Scripts/Domain/Models/ConflictTestScenarioType.cs
@@ -1,0 +1,22 @@
+/*
+ * ConflictTestScenarioType.cs
+ * ------------------------------------------------------------
+ * Enumera los escenarios controlados de conflicto disponibles para pruebas.
+ *
+ * Estos escenarios permiten validar el motor CPA/TCPA sin depender de que
+ * OpenSky proporcione en ese momento una aeronave real en trayectoria peligrosa.
+ *
+ * Se conecta con:
+ * - ConflictTestScenarioFactory: genera aeronaves simuladas.
+ * - OpenSkyApiClient: activa o desactiva estos escenarios desde el Inspector.
+ */
+
+namespace TFG.ARVisor.Domain.Models
+{
+    public enum ConflictTestScenarioType
+    {
+        SafeParallel,
+        CrossingTraffic,
+        HeadOnConflict
+    }
+}

--- a/UnityProject/tfg/Assets/Scripts/Domain/Models/ConflictTestScenarioType.cs.meta
+++ b/UnityProject/tfg/Assets/Scripts/Domain/Models/ConflictTestScenarioType.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1de6555d4557eb248ade6ebe36158405
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/tfg/Assets/Scripts/Domain/Services/ConflictTestScenarioFactory.cs
+++ b/UnityProject/tfg/Assets/Scripts/Domain/Services/ConflictTestScenarioFactory.cs
@@ -1,0 +1,197 @@
+/*
+ * ConflictTestScenarioFactory.cs
+ * ------------------------------------------------------------
+ * Genera aeronaves simuladas para probar el motor de predicción de conflicto.
+ *
+ * Escenarios incluidos:
+ * - SafeParallel: aeronave separada y no conflictiva.
+ * - CrossingTraffic: aeronave cruzando la trayectoria con riesgo medio.
+ * - HeadOnConflict: aeronave frontal con riesgo alto.
+ *
+ * Estos escenarios son de desarrollo y validación. No sustituyen al tráfico
+ * real recibido desde OpenSky, pero permiten demostrar que el motor CPA/TCPA
+ * responde correctamente ante situaciones controladas.
+ *
+ * Se conecta con:
+ * - ConflictTestScenarioType: selección del escenario.
+ * - ConflictPredictionEngine: evalúa la aeronave generada.
+ * - OpenSkyApiClient: integra el escenario en el flujo de tráfico.
+ */
+
+using System;
+using System.Collections.Generic;
+using TFG.ARVisor.Domain.Models;
+
+namespace TFG.ARVisor.Domain.Services
+{
+    public static class ConflictTestScenarioFactory
+    {
+        /// <summary>
+        /// Crea una lista con una aeronave simulada según el escenario seleccionado.
+        /// </summary>
+        public static List<AircraftGeoState> CreateScenarioAircraft(
+            OwnshipGeoState ownshipState,
+            OwnshipMotionState ownshipMotion,
+            ConflictTestScenarioType scenarioType)
+        {
+            List<AircraftGeoState> aircraft = new List<AircraftGeoState>();
+
+            if (ownshipState == null)
+            {
+                return aircraft;
+            }
+
+            double referenceTrack = GetReferenceTrack(ownshipMotion);
+            double ownshipAltitude = ownshipState.AltitudeMeters ?? 1000.0;
+
+            switch (scenarioType)
+            {
+                case ConflictTestScenarioType.HeadOnConflict:
+                    aircraft.Add(CreateHeadOnConflict(ownshipState, referenceTrack, ownshipAltitude));
+                    break;
+
+                case ConflictTestScenarioType.CrossingTraffic:
+                    aircraft.Add(CreateCrossingTraffic(ownshipState, referenceTrack, ownshipAltitude));
+                    break;
+
+                case ConflictTestScenarioType.SafeParallel:
+                default:
+                    aircraft.Add(CreateSafeParallel(ownshipState, referenceTrack, ownshipAltitude));
+                    break;
+            }
+
+            return aircraft;
+        }
+
+        /// <summary>
+        /// Obtiene el rumbo propio estimado. Si no hay movimiento fiable, usa 90 grados como referencia.
+        /// </summary>
+        private static double GetReferenceTrack(OwnshipMotionState ownshipMotion)
+        {
+            if (ownshipMotion != null &&
+                ownshipMotion.HasReliableMotion &&
+                ownshipMotion.TrackDegrees.HasValue)
+            {
+                return ownshipMotion.TrackDegrees.Value;
+            }
+
+            return 90.0;
+        }
+
+        /// <summary>
+        /// Crea una aeronave separada y no conflictiva.
+        /// Resultado esperado: LOW / PATH CLEAR.
+        /// </summary>
+        private static AircraftGeoState CreateSafeParallel(
+            OwnshipGeoState ownshipState,
+            double referenceTrack,
+            double ownshipAltitude)
+        {
+            GeoProjectionCalculator.ProjectFromLocalOffset(
+                ownshipState.Latitude,
+                ownshipState.Longitude,
+                referenceTrack,
+                forwardMeters: 60000.0,
+                rightMeters: 60000.0,
+                out double latitude,
+                out double longitude
+            );
+
+            return CreateAircraft(
+                id: "test_safe_parallel",
+                callsign: "TESTSAFE",
+                latitude: latitude,
+                longitude: longitude,
+                altitudeMeters: ownshipAltitude + 300.0,
+                velocityMps: 40.0,
+                headingDegrees: GeoBearingCalculator.Normalize360(referenceTrack + 10.0)
+            );
+        }
+
+        /// <summary>
+        /// Crea una aeronave que cruza la trayectoria propia con separación moderada.
+        /// Resultado esperado: MED / TRAJECTORY WATCH.
+        /// </summary>
+        private static AircraftGeoState CreateCrossingTraffic(
+            OwnshipGeoState ownshipState,
+            double referenceTrack,
+            double ownshipAltitude)
+        {
+            GeoProjectionCalculator.ProjectFromLocalOffset(
+                ownshipState.Latitude,
+                ownshipState.Longitude,
+                referenceTrack,
+                forwardMeters: 19000.0,
+                rightMeters: 9000.0,
+                out double latitude,
+                out double longitude
+            );
+
+            return CreateAircraft(
+                id: "test_crossing_traffic",
+                callsign: "TESTMED",
+                latitude: latitude,
+                longitude: longitude,
+                altitudeMeters: ownshipAltitude + 300.0,
+                velocityMps: 45.0,
+                headingDegrees: GeoBearingCalculator.Normalize360(referenceTrack - 90.0)
+            );
+        }
+
+        /// <summary>
+        /// Crea una aeronave frontal en sentido contrario.
+        /// Resultado esperado: HIGH / CONFLICT RISK.
+        /// </summary>
+        private static AircraftGeoState CreateHeadOnConflict(
+            OwnshipGeoState ownshipState,
+            double referenceTrack,
+            double ownshipAltitude)
+        {
+            GeoProjectionCalculator.ProjectFromLocalOffset(
+                ownshipState.Latitude,
+                ownshipState.Longitude,
+                referenceTrack,
+                forwardMeters: 20000.0,
+                rightMeters: 0.0,
+                out double latitude,
+                out double longitude
+            );
+
+            return CreateAircraft(
+                id: "test_head_on_conflict",
+                callsign: "TESTHIGH",
+                latitude: latitude,
+                longitude: longitude,
+                altitudeMeters: ownshipAltitude + 200.0,
+                velocityMps: 70.0,
+                headingDegrees: GeoBearingCalculator.Normalize360(referenceTrack + 180.0)
+            );
+        }
+
+        /// <summary>
+        /// Crea una aeronave simulada compatible con el modelo interno AircraftGeoState.
+        /// </summary>
+        private static AircraftGeoState CreateAircraft(
+            string id,
+            string callsign,
+            double latitude,
+            double longitude,
+            double altitudeMeters,
+            double velocityMps,
+            double headingDegrees)
+        {
+            return new AircraftGeoState(
+                id,
+                callsign,
+                "Test Scenario",
+                latitude,
+                longitude,
+                altitudeMeters,
+                velocityMps,
+                headingDegrees,
+                verticalRateMps: 0.0,
+                lastContactUtc: DateTimeOffset.UtcNow.ToUnixTimeSeconds()
+            );
+        }
+    }
+}

--- a/UnityProject/tfg/Assets/Scripts/Domain/Services/ConflictTestScenarioFactory.cs.meta
+++ b/UnityProject/tfg/Assets/Scripts/Domain/Services/ConflictTestScenarioFactory.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: dba9e5f2ed4fd164c9c2f4a2530c874b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/tfg/Assets/Scripts/Domain/Services/GeoProjectionCalculator.cs
+++ b/UnityProject/tfg/Assets/Scripts/Domain/Services/GeoProjectionCalculator.cs
@@ -1,0 +1,74 @@
+/*
+ * GeoProjectionCalculator.cs
+ * ------------------------------------------------------------
+ * Servicio para proyectar posiciones geográficas a partir de desplazamientos
+ * locales en metros.
+ *
+ * Permite generar aeronaves simuladas alrededor de la posición propia usando
+ * una referencia de rumbo:
+ * - forwardMeters: metros por delante del avión propio.
+ * - rightMeters: metros hacia la derecha del avión propio.
+ *
+ * Se conecta con:
+ * - ConflictTestScenarioFactory: coloca aeronaves simuladas en escenarios
+ *   controlados de conflicto.
+ */
+
+using System;
+
+namespace TFG.ARVisor.Domain.Services
+{
+    public static class GeoProjectionCalculator
+    {
+        private const double EarthRadiusMeters = 6371000.0;
+
+        /// <summary>
+        /// Proyecta una coordenada geográfica a partir de un desplazamiento local relativo
+        /// al rumbo de referencia.
+        /// </summary>
+        public static void ProjectFromLocalOffset(
+            double originLatitude,
+            double originLongitude,
+            double referenceTrackDegrees,
+            double forwardMeters,
+            double rightMeters,
+            out double targetLatitude,
+            out double targetLongitude)
+        {
+            double trackRad = DegreesToRadians(referenceTrackDegrees);
+            double rightRad = DegreesToRadians(referenceTrackDegrees + 90.0);
+
+            double eastMeters =
+                Math.Sin(trackRad) * forwardMeters +
+                Math.Sin(rightRad) * rightMeters;
+
+            double northMeters =
+                Math.Cos(trackRad) * forwardMeters +
+                Math.Cos(rightRad) * rightMeters;
+
+            double originLatRad = DegreesToRadians(originLatitude);
+
+            double deltaLatRad = northMeters / EarthRadiusMeters;
+            double deltaLonRad = eastMeters / (EarthRadiusMeters * Math.Cos(originLatRad));
+
+            targetLatitude = originLatitude + RadiansToDegrees(deltaLatRad);
+            targetLongitude = originLongitude + RadiansToDegrees(deltaLonRad);
+        }
+
+        /// <summary>
+        /// Convierte grados a radianes.
+        /// </summary>
+        private static double DegreesToRadians(double degrees)
+        {
+            return degrees * Math.PI / 180.0;
+        }
+
+        /// <summary>
+        /// Convierte radianes a grados.
+        /// </summary>
+        private static double RadiansToDegrees(double radians)
+        {
+            return radians * 180.0 / Math.PI;
+        }
+    }
+}

--- a/UnityProject/tfg/Assets/Scripts/Domain/Services/GeoProjectionCalculator.cs.meta
+++ b/UnityProject/tfg/Assets/Scripts/Domain/Services/GeoProjectionCalculator.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7612a27c2babf334f855c418c50ac989
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/tfg/Assets/Scripts/Infrastructure/ApiClients/OpenSkyApiClient.cs
+++ b/UnityProject/tfg/Assets/Scripts/Infrastructure/ApiClients/OpenSkyApiClient.cs
@@ -75,6 +75,10 @@ namespace TFG.ARVisor.Infrastructure.ApiClients
         [SerializeField] private bool logConflictPredictionToConsole = true;
         [SerializeField] private float conflictLogIntervalSeconds = 3f;
 
+        [Header("Conflict Test Scenarios")]
+        [SerializeField] private bool useConflictTestScenario = false;
+        [SerializeField] private ConflictTestScenarioType conflictTestScenario = ConflictTestScenarioType.SafeParallel;
+        [SerializeField] private bool includeRealTrafficWithTestScenario = false;
 
 
         private Coroutine pollingCoroutine;
@@ -96,8 +100,8 @@ namespace TFG.ARVisor.Infrastructure.ApiClients
         }
 
         /// <summary>
-        /// Recalcula periódicamente qué aeronave debe mostrarse en el HUD usando
-        /// los últimos datos recibidos desde OpenSky, sin realizar nuevas peticiones a la API.
+        /// Recalcula periódicamente el HUD usando datos cacheados o escenarios de prueba.
+        /// En modo escenario de conflicto, no depende de nuevas respuestas de OpenSky.
         /// </summary>
         private void Update()
         {
@@ -107,6 +111,12 @@ namespace TFG.ARVisor.Infrastructure.ApiClients
             }
 
             nextHudTargetRefreshTime = Time.time + hudTargetRefreshSeconds;
+
+            if (useConflictTestScenario && !includeRealTrafficWithTestScenario)
+            {
+                RefreshConflictTestScenarioFromCurrentGps();
+                return;
+            }
 
             RefreshHudTargetFromCachedTraffic();
         }
@@ -124,16 +134,21 @@ namespace TFG.ARVisor.Infrastructure.ApiClients
         }
 
         /// <summary>
-        /// Ejecuta consultas periódicas a OpenSky cada cierto número de segundos.
-        /// </summary>
-        private IEnumerator PollOpenSkyLoop()
+/// Ejecuta consultas periódicas a OpenSky.
+/// Si se está usando un escenario controlado sin tráfico real, no consulta OpenSky.
+/// </summary>
+private IEnumerator PollOpenSkyLoop()
+{
+    while (true)
+    {
+        if (!useConflictTestScenario || includeRealTrafficWithTestScenario)
         {
-            while (true)
-            {
-                yield return FetchCurrentTraffic();
-                yield return new WaitForSeconds(refreshSeconds);
-            }
+            yield return FetchCurrentTraffic();
         }
+
+        yield return new WaitForSeconds(refreshSeconds);
+    }
+}
 
         /// <summary>
         /// Obtiene la posición propia, genera la bounding box y lanza la petición HTTP a OpenSky.
@@ -221,8 +236,13 @@ namespace TFG.ARVisor.Infrastructure.ApiClients
                 ownshipState,
                 aircraft,
                 searchRadiusKm
+                
             );
-
+        nearbyAircraft = ApplyConflictTestScenario(
+                ownshipState,
+                nearbyAircraft
+            );
+        
             Debug.Log(
                 $"OpenSky aircraft parsed: {aircraft.Count}. " +
                 $"Inside {searchRadiusKm:0} KM: {nearbyAircraft.Count}"
@@ -871,7 +891,129 @@ private void LogConflictAssessment(ConflictAssessment conflictAssessment)
         $"Reason: {conflictAssessment.Reason}"
     );
 }
+
+
+
+/// <summary>
+/// Aplica un escenario controlado de conflicto para pruebas.
+/// Si está activado, puede reemplazar el tráfico real o combinarlo con el escenario simulado.
+/// </summary>
+private List<AircraftGeoState> ApplyConflictTestScenario(
+    OwnshipGeoState ownshipState,
+    List<AircraftGeoState> realNearbyAircraft)
+{
+    if (!useConflictTestScenario)
+    {
+        return realNearbyAircraft;
     }
+
+    OwnshipMotionState motionState = GetMotionStateForConflictScenario(ownshipState);
+
+    List<AircraftGeoState> scenarioAircraft =
+        TFG.ARVisor.Domain.Services.ConflictTestScenarioFactory.CreateScenarioAircraft(
+            ownshipState,
+            motionState,
+            conflictTestScenario
+        );
+
+    if (includeRealTrafficWithTestScenario)
+    {
+        List<AircraftGeoState> combinedAircraft = new List<AircraftGeoState>();
+
+        if (realNearbyAircraft != null)
+        {
+            combinedAircraft.AddRange(realNearbyAircraft);
+        }
+
+        combinedAircraft.AddRange(scenarioAircraft);
+
+        return combinedAircraft;
+    }
+
+    return scenarioAircraft;
+}
+
+
+
+
+/// <summary>
+/// Actualiza el HUD usando únicamente un escenario controlado de conflicto.
+/// Este modo no depende de OpenSky y permite probar LOW / MED / HIGH desde el Inspector.
+/// </summary>
+private void RefreshConflictTestScenarioFromCurrentGps()
+{
+    if (gpsProvider == null || gpsProvider.CurrentState == null)
+    {
+        return;
+    }
+
+    OwnshipGeoState ownshipState = gpsProvider.CurrentState;
+
+    OwnshipMotionState motionState = GetMotionStateForConflictScenario(ownshipState);
+
+    List<AircraftGeoState> scenarioAircraft =
+        TFG.ARVisor.Domain.Services.ConflictTestScenarioFactory.CreateScenarioAircraft(
+            ownshipState,
+            motionState,
+            conflictTestScenario
+        );
+
+    RiskAssessment riskAssessment = RiskEngine.Evaluate(
+        ownshipState,
+        scenarioAircraft
+    );
+
+    ConflictAssessment conflictAssessment = ConflictPredictionEngine.EvaluateMostCritical(
+        ownshipState,
+        motionState,
+        scenarioAircraft
+    );
+
+    lastOwnshipState = ownshipState;
+    lastNearbyAircraft = scenarioAircraft;
+    lastRiskAssessment = riskAssessment;
+    lastConflictAssessment = conflictAssessment;
+
+    AircraftTargetSelectionResult targetSelection = SelectHudTarget(
+        ownshipState,
+        scenarioAircraft
+    );
+
+    UpdateHudWithRisk(
+        riskAssessment,
+        targetSelection,
+        conflictAssessment
+    );
+}
+
+
+
+/// <summary>
+/// Devuelve el movimiento propio que se usará para escenarios de prueba.
+/// Si el estimador todavía no tiene movimiento fiable, crea una referencia simulada segura
+/// para que los escenarios puedan probarse desde el primer momento.
+/// </summary>
+private OwnshipMotionState GetMotionStateForConflictScenario(OwnshipGeoState ownshipState)
+{
+    OwnshipMotionState motionState = motionEstimator != null
+        ? motionEstimator.CurrentMotionState
+        : null;
+
+    if (motionState != null && motionState.HasReliableMotion)
+    {
+        return motionState;
+    }
+
+    return new OwnshipMotionState(
+        hasReliableMotion: true,
+        trackDegrees: 90.0,
+        speedMps: 45.0,
+        altitudeMeters: ownshipState != null ? ownshipState.AltitudeMeters : null,
+        reason: "Fallback scenario motion."
+    );
+}
+    }
+
 
     
 }


### PR DESCRIPTION
## Qué se ha hecho

- Se han añadido escenarios controlados de conflicto para pruebas.
- Se ha creado un generador de aeronaves simuladas alrededor de la posición propia.
- Se han añadido tres escenarios:
  - Safe Parallel
  - Crossing Traffic
  - Head On Conflict
- Se ha integrado el modo de escenarios con el flujo del HUD.
- Se permite activar/desactivar los escenarios desde el Inspector.
- Se puede elegir si usar solo el escenario simulado o combinarlo con tráfico real.
- El modo de escenarios funciona sin depender de nuevas respuestas de OpenSky.
- Se han calibrado los escenarios para representar casos LOW, MED y HIGH.

## Pruebas realizadas

- Safe Parallel muestra un caso seguro con riesgo bajo.
- Crossing Traffic muestra un caso de vigilancia de trayectoria.
- Head On Conflict muestra un caso de conflicto de alto riesgo.
- El HUD cambia correctamente entre PATH CLEAR, TRAJECTORY WATCH y CONFLICT RISK.
- El sistema compila correctamente en Unity.

## Próximo paso

- Añadir un indicador visual del target en el HUD.
- Mejorar la presentación visual del conflicto.
- Preparar futuras visualizaciones AR más avanzadas.