### PR TITLE
Redesign HUD visual experience

### DIFF
--- a/UnityProject/tfg/Assets/Samples/XR Interaction Toolkit/3.1.2/Hands Interaction Demo/Prefabs/XR Origin Hands (XR Rig).prefab
+++ b/UnityProject/tfg/Assets/Samples/XR Interaction Toolkit/3.1.2/Hands Interaction Demo/Prefabs/XR Origin Hands (XR Rig).prefab
@@ -24,13 +24,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 184753855263555647}
+  serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 5878492368827077393}
-  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &9051997425903558535
 MonoBehaviour:
@@ -125,13 +125,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 317924410297350442}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 1
   m_Children: []
   m_Father: {fileID: 2609991494921256999}
-  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &488363206831216342
 MonoBehaviour:
@@ -201,13 +201,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 927309121262695183}
+  serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 657184242161839408}
-  m_RootOrder: 9
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &3922177026488651056
 MonoBehaviour:
@@ -257,13 +257,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1203898232706430911}
+  serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 5878492368827077393}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &6237049687586235588
 MonoBehaviour:
@@ -414,6 +414,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1800725127586568702}
+  serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
@@ -426,7 +427,6 @@ Transform:
   - {fileID: 4894638449106479503}
   - {fileID: 2062385652673493497}
   m_Father: {fileID: 657184242161839408}
-  m_RootOrder: 8
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &6560933994651781378
 MonoBehaviour:
@@ -707,13 +707,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2611266366292535140}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 1
   m_Children: []
   m_Father: {fileID: 2609991494921256999}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &6730044672306722172
 MonoBehaviour:
@@ -783,13 +783,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 3216986067806868489}
+  serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 6311120899289156754}
-  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &2930949565896419353
 MonoBehaviour:
@@ -884,13 +884,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 3731119764064029736}
+  serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 5878492368827077393}
-  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &7217514538655570714
 MonoBehaviour:
@@ -985,13 +985,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 3892329699652493770}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 1
   m_Children: []
   m_Father: {fileID: 5083622343426082761}
-  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &781544023858974861
 MonoBehaviour:
@@ -1061,13 +1061,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 4605643766788160351}
+  serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 1
   m_Children: []
   m_Father: {fileID: 2218496723442559053}
-  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &4353042875904107839
 MonoBehaviour:
@@ -1107,13 +1107,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 5323647229090770512}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 1
   m_Children: []
   m_Father: {fileID: 5083622343426082761}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &4234401886418808293
 MonoBehaviour:
@@ -1183,13 +1183,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 5780998334867579440}
+  serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 6311120899289156754}
-  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &2034475846792841991
 MonoBehaviour:
@@ -1285,13 +1285,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 6003869514719898561}
+  serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 6311120899289156754}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &8209797214075343310
 MonoBehaviour:
@@ -1442,6 +1442,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 6355494128053973299}
+  serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
@@ -1454,7 +1455,6 @@ Transform:
   - {fileID: 1176872742605197438}
   - {fileID: 4399806423645351520}
   m_Father: {fileID: 657184242161839408}
-  m_RootOrder: 7
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &3510802014482765209
 MonoBehaviour:

--- a/UnityProject/tfg/Assets/Samples/XR Interaction Toolkit/3.1.2/Starter Assets/Prefabs/XR Origin (XR Rig).prefab
+++ b/UnityProject/tfg/Assets/Samples/XR Interaction Toolkit/3.1.2/Starter Assets/Prefabs/XR Origin (XR Rig).prefab
@@ -27,6 +27,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 202364687}
+  serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
@@ -37,7 +38,6 @@ Transform:
   - {fileID: 1319746309}
   - {fileID: 8366379412631108205}
   m_Father: {fileID: 1680501587}
-  m_RootOrder: -2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &4778211696441940833
 MonoBehaviour:
@@ -210,6 +210,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1670256624}
+  serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
@@ -220,7 +221,6 @@ Transform:
   - {fileID: 2449787133337329436}
   - {fileID: 6528530117482412838}
   m_Father: {fileID: 1680501587}
-  m_RootOrder: -2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &5663893676086941514
 MonoBehaviour:
@@ -389,6 +389,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1680501586}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 1.36144, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
@@ -402,7 +403,6 @@ Transform:
   - {fileID: 1670256625}
   - {fileID: 8718302446126152263}
   m_Father: {fileID: 1717954561962503726}
-  m_RootOrder: -2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1767192433
 GameObject:
@@ -431,13 +431,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1767192433}
+  serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1680501587}
-  m_RootOrder: -2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!20 &1767192439
 Camera:
@@ -637,12 +637,12 @@ MonoBehaviour:
   m_RequiresColorTexture: 0
   m_Version: 2
   m_TaaSettings:
-    quality: 3
-    frameInfluence: 0.1
-    jitterScale: 1
-    mipBias: 0
-    varianceClampScale: 0.9
-    contrastAdaptiveSharpening: 0
+    m_Quality: 3
+    m_FrameInfluence: 0.1
+    m_JitterScale: 1
+    m_MipBias: 0
+    m_VarianceClampScale: 0.9
+    m_ContrastAdaptiveSharpening: 0
 --- !u!1 &58445280694286476
 GameObject:
   m_ObjectHideFlags: 0
@@ -667,13 +667,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 58445280694286476}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 6981642495833523204}
-  m_RootOrder: -2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &153982007679157697
 MonoBehaviour:
@@ -752,13 +752,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1316853283282549446}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 6981642495833523204}
-  m_RootOrder: -2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &658028464602686504
 MonoBehaviour:
@@ -816,13 +816,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1470279098769358944}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 6981642495833523204}
-  m_RootOrder: -2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &7347985736721345035
 MonoBehaviour:
@@ -944,6 +944,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1717954561962503725}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
@@ -952,7 +953,6 @@ Transform:
   - {fileID: 1680501587}
   - {fileID: 6981642495833523204}
   m_Father: {fileID: 0}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &1178791450436251564
 MonoBehaviour:
@@ -1090,13 +1090,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1787516059220952802}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 8718302446126152263}
-  m_RootOrder: -2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &2190828208922718286
 GameObject:
@@ -1122,13 +1122,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2190828208922718286}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 6981642495833523204}
-  m_RootOrder: -2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &1748222016861356527
 MonoBehaviour:
@@ -1169,6 +1169,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2626757739553014894}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
@@ -1176,7 +1177,6 @@ Transform:
   m_Children:
   - {fileID: 2749926995908329476}
   m_Father: {fileID: 6981642495833523204}
-  m_RootOrder: -2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &5739245880472075158
 MonoBehaviour:
@@ -1226,6 +1226,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2766569358201078490}
+  serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
@@ -1233,7 +1234,6 @@ Transform:
   m_Children:
   - {fileID: 150171005766949883}
   m_Father: {fileID: 1680501587}
-  m_RootOrder: -2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &1801942220539511183
 MonoBehaviour:
@@ -1278,13 +1278,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 3533369827395663398}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 6981642495833523204}
-  m_RootOrder: -2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &2032798983271290625
 MonoBehaviour:
@@ -1466,13 +1466,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 3904471525139099824}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 6981642495833523204}
-  m_RootOrder: -2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &7054646180837666701
 MonoBehaviour:
@@ -1550,13 +1550,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 4026763789982141574}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 716906830792148215}
-  m_RootOrder: -2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &5167925059111895691
 GameObject:
@@ -1583,6 +1583,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 5167925059111895691}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
@@ -1596,7 +1597,6 @@ Transform:
   - {fileID: 1930236392004951510}
   - {fileID: 7951184429302108679}
   m_Father: {fileID: 1717954561962503726}
-  m_RootOrder: -2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &6640002710935096923
 MonoBehaviour:
@@ -1650,6 +1650,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 5563199296126487199}
+  serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
@@ -1657,7 +1658,6 @@ Transform:
   m_Children:
   - {fileID: 5556032914392612086}
   m_Father: {fileID: 1680501587}
-  m_RootOrder: -2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &3752199730057449385
 MonoBehaviour:
@@ -1701,13 +1701,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 5617778599117486727}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 8418786636219059989}
-  m_RootOrder: -2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &758862941726224967
 MonoBehaviour:
@@ -1793,6 +1793,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 6501755809687671949}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
@@ -1800,7 +1801,6 @@ Transform:
   m_Children:
   - {fileID: 8381546940850731792}
   m_Father: {fileID: 1680501587}
-  m_RootOrder: -2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &9068281059075228377
 MonoBehaviour:
@@ -1842,13 +1842,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 6553456492286146741}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 3595914740002285240}
-  m_RootOrder: -2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &494449108016059778
 PrefabInstance:
@@ -1975,6 +1975,10 @@ PrefabInstance:
     - target: {fileID: 2761784063978902504, guid: c1800acf6366418a9b5f610249000331, type: 3}
       propertyPath: m_Parameters.numCapVertices
       value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 2761784063978902504, guid: c1800acf6366418a9b5f610249000331, type: 3}
+      propertyPath: m_Parameters.widthMultiplier
+      value: 0.01
       objectReference: {fileID: 0}
     - target: {fileID: 2761784063978902504, guid: c1800acf6366418a9b5f610249000331, type: 3}
       propertyPath: m_Parameters.numCornerVertices
@@ -2222,6 +2226,10 @@ PrefabInstance:
     - target: {fileID: 2761784063978902504, guid: c1800acf6366418a9b5f610249000331, type: 3}
       propertyPath: m_Parameters.numCapVertices
       value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 2761784063978902504, guid: c1800acf6366418a9b5f610249000331, type: 3}
+      propertyPath: m_Parameters.widthMultiplier
+      value: 0.01
       objectReference: {fileID: 0}
     - target: {fileID: 2761784063978902504, guid: c1800acf6366418a9b5f610249000331, type: 3}
       propertyPath: m_Parameters.numCornerVertices

--- a/UnityProject/tfg/Assets/Scenes/MainScene.unity
+++ b/UnityProject/tfg/Assets/Scenes/MainScene.unity
@@ -1336,8 +1336,13 @@ MonoBehaviour:
   cornerLength: 34
   cornerThickness: 4
   backgroundAlpha: 0.12
+  fadeSpeed: 6
   highPulseSpeed: 4
   highPulseAmount: 0.18
+  showScanLine: 1
+  scanLineSpeed: 0.8
+  scanLineThickness: 2
+  scanLineAlpha: 0.35
   mediumFontSize: 20
   highFontSize: 24
 --- !u!225 &1835194829
@@ -1440,7 +1445,7 @@ MonoBehaviour:
   logRawJsonPreview: 0
   logConflictPredictionToConsole: 1
   conflictLogIntervalSeconds: 3
-  useConflictTestScenario: 1
+  useConflictTestScenario: 0
   conflictTestScenario: 2
   includeRealTrafficWithTestScenario: 0
 --- !u!4 &2058325481

--- a/UnityProject/tfg/Assets/Scripts/Infrastructure/GPS/ExternalGpsProvider.cs
+++ b/UnityProject/tfg/Assets/Scripts/Infrastructure/GPS/ExternalGpsProvider.cs
@@ -127,6 +127,12 @@ namespace TFG.ARVisor.Infrastructure.Gps
                 mode: modeText,
                 updateRate: updateRateText
             );
+
+            hudController.RenderGpsCoordinates(
+                CurrentState.Latitude,
+                CurrentState.Longitude,
+                CurrentState.AltitudeMeters
+            );
         }
 
         private void UpdateHudWaiting()

--- a/UnityProject/tfg/Assets/Scripts/Presentation/HUD/HudAlertBanner.cs
+++ b/UnityProject/tfg/Assets/Scripts/Presentation/HUD/HudAlertBanner.cs
@@ -1,0 +1,46 @@
+using TMPro; using UnityEngine; using UnityEngine.UI;
+namespace TFG.ARVisor.Presentation.HUD {
+[RequireComponent(typeof(Canvas))][RequireComponent(typeof(CanvasGroup))]
+public class HudAlertBanner : MonoBehaviour {
+    const float PW=380f,PH=34f,WS=0.003f;
+    Canvas _cv; CanvasGroup _cg;
+    RawImage _bg,_lBar,_rBar; TMP_Text _txt;
+    void Awake(){
+        _cv=GetComponent<Canvas>(); _cv.renderMode=RenderMode.WorldSpace; _cv.sortingOrder=99;
+        if(Camera.main!=null)_cv.worldCamera=Camera.main;
+        _cg=GetComponent<CanvasGroup>(); _cg.interactable=false; _cg.blocksRaycasts=false;
+        var rt=GetComponent<RectTransform>(); rt.sizeDelta=new Vector2(PW,PH);
+        transform.localScale=Vector3.one*WS; Build(); gameObject.SetActive(false);
+    }
+    void Build(){
+        _bg=I("BG",transform); S(_bg.rectTransform); _bg.color=HudVisualTheme.PanelBg;
+        _lBar=I("L",transform); var lr=_lBar.rectTransform;
+        lr.anchorMin=new Vector2(0f,0.15f); lr.anchorMax=new Vector2(0f,0.85f);
+        lr.pivot=new Vector2(0f,0.5f); lr.anchoredPosition=Vector2.zero; lr.sizeDelta=new Vector2(2f,0f);
+        _lBar.color=HudVisualTheme.ColorIdle;
+        _rBar=I("R",transform); var rr=_rBar.rectTransform;
+        rr.anchorMin=new Vector2(1f,0.15f); rr.anchorMax=new Vector2(1f,0.85f);
+        rr.pivot=new Vector2(1f,0.5f); rr.anchoredPosition=Vector2.zero; rr.sizeDelta=new Vector2(2f,0f);
+        _rBar.color=HudVisualTheme.ColorIdle;
+        _txt=T("Txt",transform,11.5f); var tr=_txt.rectTransform;
+        tr.anchorMin=Vector2.zero; tr.anchorMax=Vector2.one;
+        tr.offsetMin=new Vector2(8f,0f); tr.offsetMax=new Vector2(-8f,0f);
+        _txt.alignment=TMPro.TextAlignmentOptions.Center;
+    }
+    public void ShowMedium(string msg){
+        gameObject.SetActive(true);
+        if(_lBar)_lBar.color=HudVisualTheme.ColorMedium;
+        if(_rBar)_rBar.color=HudVisualTheme.ColorMedium;
+        if(_txt)_txt.text=$"<color={HudVisualTheme.HexMedium}>{msg}</color>";
+    }
+    public void ShowHigh(string msg){
+        gameObject.SetActive(true);
+        if(_lBar)_lBar.color=HudVisualTheme.ColorHigh;
+        if(_rBar)_rBar.color=HudVisualTheme.ColorHigh;
+        if(_txt)_txt.text=$"<color={HudVisualTheme.HexHigh}>{msg}</color>";
+    }
+    public void Hide(){ gameObject.SetActive(false); }
+    static RawImage I(string n,Transform p){ var go=new GameObject(n,typeof(RectTransform),typeof(CanvasRenderer),typeof(RawImage)); go.transform.SetParent(p,false); var i=go.GetComponent<RawImage>(); i.texture=UnityEngine.Texture2D.whiteTexture; i.raycastTarget=false; return i; }
+    static TMP_Text T(string n,Transform p,float sz){ var go=new GameObject(n,typeof(RectTransform),typeof(CanvasRenderer),typeof(TMPro.TextMeshProUGUI)); go.transform.SetParent(p,false); var t=go.GetComponent<TMP_Text>(); t.fontSize=sz; t.enableWordWrapping=false; t.raycastTarget=false; t.richText=true; t.color=HudVisualTheme.ColorWhite; t.text=""; return t; }
+    static void S(RectTransform rt){ rt.anchorMin=Vector2.zero; rt.anchorMax=Vector2.one; rt.offsetMin=Vector2.zero; rt.offsetMax=Vector2.zero; }
+}}

--- a/UnityProject/tfg/Assets/Scripts/Presentation/HUD/HudAlertBanner.cs.meta
+++ b/UnityProject/tfg/Assets/Scripts/Presentation/HUD/HudAlertBanner.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c0674e0bf45cec04aad6e7da249ff2c3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/tfg/Assets/Scripts/Presentation/HUD/HudAnimator.cs
+++ b/UnityProject/tfg/Assets/Scripts/Presentation/HUD/HudAnimator.cs
@@ -1,0 +1,60 @@
+/*
+ * HudAnimator.cs
+ * ------------------------------------------------------------
+ * Gestiona animaciones de color (pulse) para textos TMP del HUD.
+ * Se añade como componente al mismo GameObject que HudController.
+ * HudController lo registra y llama a StartPulse / StopPulse según el riesgo.
+ */
+
+using System.Collections.Generic;
+using TMPro;
+using UnityEngine;
+
+namespace TFG.ARVisor.Presentation.HUD
+{
+    public class HudAnimator : MonoBehaviour
+    {
+        private class PulseJob
+        {
+            public TMP_Text Target;
+            public Color    ColorA;
+            public Color    ColorB;
+            public float    Speed;
+        }
+
+        private readonly List<PulseJob> _jobs = new List<PulseJob>();
+
+        // ── Public API ────────────────────────────────────────────────
+
+        public void StartPulse(TMP_Text text, Color colorA, Color colorB, float speed = 2.5f)
+        {
+            if (text == null) return;
+            StopPulse(text);
+            _jobs.Add(new PulseJob { Target = text, ColorA = colorA, ColorB = colorB, Speed = speed });
+        }
+
+        public void StopPulse(TMP_Text text)
+        {
+            if (text == null) return;
+            _jobs.RemoveAll(j => j.Target == text);
+        }
+
+        public void StopAll()
+        {
+            _jobs.Clear();
+        }
+
+        // ── Unity ─────────────────────────────────────────────────────
+
+        private void Update()
+        {
+            for (int i = _jobs.Count - 1; i >= 0; i--)
+            {
+                var job = _jobs[i];
+                if (job.Target == null) { _jobs.RemoveAt(i); continue; }
+                float t = (Mathf.Sin(Time.time * job.Speed) * 0.5f) + 0.5f;
+                job.Target.color = Color.Lerp(job.ColorA, job.ColorB, t);
+            }
+        }
+    }
+}

--- a/UnityProject/tfg/Assets/Scripts/Presentation/HUD/HudAnimator.cs.meta
+++ b/UnityProject/tfg/Assets/Scripts/Presentation/HUD/HudAnimator.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b8ae1ae57f384c54ba19d23a08b486b1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/tfg/Assets/Scripts/Presentation/HUD/HudCompassStrip.cs
+++ b/UnityProject/tfg/Assets/Scripts/Presentation/HUD/HudCompassStrip.cs
@@ -1,0 +1,79 @@
+using TMPro; using UnityEngine; using UnityEngine.UI;
+using TFG.ARVisor.Domain.Models;
+namespace TFG.ARVisor.Presentation.HUD {
+[RequireComponent(typeof(Canvas))][RequireComponent(typeof(CanvasGroup))]
+public class HudCompassStrip : MonoBehaviour {
+    const float PW=640f,PH=54f,WS=0.003f;
+    const int STEPS=9,DS=10;
+    Canvas _cv; CanvasGroup _cg;
+    RawImage _bg,_topL,_botL,_cMark;
+    RawImage[] _ticks = new RawImage[STEPS];
+    TMP_Text[] _nums  = new TMP_Text[STEPS];
+    TMP_Text _hdg;
+    double _tBear=double.NaN; RiskLevel _risk=RiskLevel.Low; bool _hasTgt;
+
+    void Awake(){
+        _cv=GetComponent<Canvas>(); _cv.renderMode=RenderMode.WorldSpace; _cv.sortingOrder=98;
+        if(Camera.main!=null)_cv.worldCamera=Camera.main;
+        _cg=GetComponent<CanvasGroup>(); _cg.interactable=false; _cg.blocksRaycasts=false;
+        var rt=GetComponent<RectTransform>(); rt.sizeDelta=new Vector2(PW,PH);
+        transform.localScale=Vector3.one*WS; Build();
+    }
+    void Build(){
+        _bg=Img("BG",transform); Str(_bg.rectTransform); _bg.color=new Color(0f,0f,0f,0f);
+        _topL=HLine("TL",transform,1f,true); _topL.color=new Color(1f,1f,1f,0.18f);
+        _botL=HLine("BL",transform,1f,false); _botL.color=new Color(0f,0f,0f,0f);
+        _cMark=Img("CM",transform);
+        var cm=_cMark.rectTransform;
+        cm.anchorMin=new Vector2(0.5f,1f); cm.anchorMax=new Vector2(0.5f,1f);
+        cm.pivot=new Vector2(0.5f,1f); cm.anchoredPosition=Vector2.zero; cm.sizeDelta=new Vector2(2f,7f);
+        _cMark.color=Color.white;
+        float slotW=66f, startX=-(STEPS/2)*slotW;
+        for(int i=0;i<STEPS;i++){
+            float xp=startX+i*slotW;
+            _ticks[i]=Img("TK"+i,transform);
+            var tr=_ticks[i].rectTransform;
+            tr.anchorMin=new Vector2(0.5f,0.52f); tr.anchorMax=new Vector2(0.5f,0.52f);
+            tr.pivot=new Vector2(0.5f,0f);
+            tr.anchoredPosition=new Vector2(xp,0f); tr.sizeDelta=new Vector2(1.5f,9f);
+            _ticks[i].color=new Color(1f,1f,1f,0.30f);
+            _nums[i]=Lbl("NM"+i,transform,9.5f);
+            var nr=_nums[i].rectTransform;
+            nr.anchorMin=new Vector2(0.5f,0f); nr.anchorMax=new Vector2(0.5f,0.52f);
+            nr.offsetMin=new Vector2(xp-32f,2f); nr.offsetMax=new Vector2(xp+32f,0f);
+        }
+        _hdg=Lbl("HDG",transform,8.5f);
+        var hr=_hdg.rectTransform;
+        hr.anchorMin=new Vector2(0.5f,0f); hr.anchorMax=new Vector2(0.5f,0.52f);
+        hr.offsetMin=new Vector2(-20f,-1f); hr.offsetMax=new Vector2(20f,0f);
+    }
+    void Update(){
+        float yaw=Camera.main!=null?Camera.main.transform.eulerAngles.y:0f;
+        int center=UnityEngine.Mathf.RoundToInt(yaw/DS)*DS;
+        for(int i=0;i<STEPS;i++){
+            int raw=center+(i-STEPS/2)*DS;
+            int nd=((raw%360)+360)%360;
+            bool isc=(i==STEPS/2), ist=_hasTgt&&Near(nd,_tBear,9f);
+            bool isCard=Card(nd)!=null;
+            string lbl=Card(nd)??(nd==0?"N":$"{nd:000}");
+            string col=isc?"#FFFFFF":ist?HudVisualTheme.GetRiskHex(_risk):isCard?HudVisualTheme.HexIdle:HudVisualTheme.HexDim;
+            if(_nums[i]!=null)_nums[i].text=$"<color={col}>{lbl}</color>";
+            if(_ticks[i]!=null){
+                float h=isc?14f:isCard?11f:7f;
+                _ticks[i].rectTransform.sizeDelta=new Vector2(1.5f,h);
+                _ticks[i].color=isc?Color.white:ist?HudVisualTheme.GetRiskColor(_risk):new Color(1f,1f,1f,isCard?0.45f:0.20f);
+            }
+        }
+        if(_hdg!=null)_hdg.text=$"<color={HudVisualTheme.HexDim}>{(int)yaw:000}</color>";
+        Color lc=_hasTgt?HudVisualTheme.GetRiskColor(_risk):new Color(1f,1f,1f,0.18f);
+        if(_topL)_topL.color=lc;
+    }
+    public void SetTarget(double b,RiskLevel r){_tBear=b;_risk=r;_hasTgt=true;}
+    public void ClearTarget(){_tBear=double.NaN;_hasTgt=false;_risk=RiskLevel.Low;}
+    static bool Near(int nd,double b,float t){if(double.IsNaN(b))return false;return UnityEngine.Mathf.Abs(UnityEngine.Mathf.DeltaAngle(nd,(float)b))<=t;}
+    static string Card(int d){switch(d){case 0:return"N";case 45:return"NE";case 90:return"E";case 135:return"SE";case 180:return"S";case 225:return"SW";case 270:return"W";case 315:return"NW";default:return null;}}
+    static RawImage Img(string n,Transform p){var go=new GameObject(n,typeof(RectTransform),typeof(CanvasRenderer),typeof(RawImage));go.transform.SetParent(p,false);var i=go.GetComponent<RawImage>();i.texture=UnityEngine.Texture2D.whiteTexture;i.raycastTarget=false;return i;}
+    static TMP_Text Lbl(string n,Transform p,float sz){var go=new GameObject(n,typeof(RectTransform),typeof(CanvasRenderer),typeof(TMPro.TextMeshProUGUI));go.transform.SetParent(p,false);var t=go.GetComponent<TMP_Text>();t.fontSize=sz;t.alignment=TMPro.TextAlignmentOptions.Center;t.enableWordWrapping=false;t.raycastTarget=false;t.richText=true;t.color=HudVisualTheme.ColorWhite;t.text="";return t;}
+    static RawImage HLine(string n,Transform p,float h,bool top){var i=Img(n,p);var r=i.rectTransform;r.anchorMin=new Vector2(0f,top?1f:0f);r.anchorMax=new Vector2(1f,top?1f:0f);r.pivot=new Vector2(0.5f,top?1f:0f);r.offsetMin=Vector2.zero;r.offsetMax=Vector2.zero;r.sizeDelta=new Vector2(0f,h);return i;}
+    static void Str(RectTransform r){r.anchorMin=Vector2.zero;r.anchorMax=Vector2.one;r.offsetMin=Vector2.zero;r.offsetMax=Vector2.zero;}
+}}

--- a/UnityProject/tfg/Assets/Scripts/Presentation/HUD/HudCompassStrip.cs.meta
+++ b/UnityProject/tfg/Assets/Scripts/Presentation/HUD/HudCompassStrip.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2c908857ccfe4314098b074e461e2258
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/tfg/Assets/Scripts/Presentation/HUD/HudCompassWidget.cs
+++ b/UnityProject/tfg/Assets/Scripts/Presentation/HUD/HudCompassWidget.cs
@@ -1,0 +1,107 @@
+/*
+ * HudCompassWidget.cs  —  v0.10-alpha
+ * Brujula visual tipo franja con N/NE/E/SE/S/SW/W/NW.
+ * Heading actual entre [brackets]. Target con >> en MED/HIGH.
+ * Usa TextMeshPro 3D, sin Canvas.
+ */
+using System.Text;
+using TMPro;
+using UnityEngine;
+using TFG.ARVisor.Domain.Models;
+
+namespace TFG.ARVisor.Presentation.HUD
+{
+    public class HudCompassWidget : MonoBehaviour
+    {
+        private const int   STEPS = 9;
+        private const int   DSTEP = 10;
+        private const float TARC  = 9f;
+
+        private double    _bearing = double.NaN;
+        private RiskLevel _risk    = RiskLevel.Low;
+        private bool      _hasTgt;
+
+        private TMP_Text _strip;
+        private TMP_Text _hdg;
+
+        private void Awake()
+        {
+            _strip = MakeTmp("HUD_CompassStrip", Vector3.zero, 4.5f, TextAlignmentOptions.Center);
+            _hdg   = MakeTmp("HUD_CompassHdg", new Vector3(0f, -0.065f, 0f), 3.5f, TextAlignmentOptions.Center);
+        }
+
+        private TMP_Text MakeTmp(string name, Vector3 pos, float size, TextAlignmentOptions align)
+        {
+            var go = new GameObject(name);
+            go.transform.SetParent(transform, false);
+            go.transform.localPosition = pos;
+            go.transform.localRotation = Quaternion.identity;
+            go.transform.localScale    = Vector3.one * HudVisualTheme.DefaultWorldScale;
+            var t                      = go.AddComponent<TextMeshPro>();
+            t.fontSize                 = size;
+            t.alignment                = align;
+            t.enableWordWrapping       = false;
+            t.raycastTarget            = false;
+            t.richText                 = true;
+            t.color                    = HudVisualTheme.ColorWhite;
+            t.text                     = "";
+            return t;
+        }
+
+        private void Update()
+        {
+            if (_strip == null) return;
+            float yaw = Camera.main != null ? Camera.main.transform.eulerAngles.y : 0f;
+            _strip.text = BuildStrip(yaw);
+            if (_hdg != null)
+                _hdg.text = $"<color={HudVisualTheme.HexDim}>{(int)yaw:000}</color>";
+        }
+
+        private string BuildStrip(float cy)
+        {
+            int center = Mathf.RoundToInt(cy / DSTEP) * DSTEP;
+            int half   = STEPS / 2;
+            var sb     = new StringBuilder();
+            for (int i = 0; i < STEPS; i++)
+            {
+                int rd  = center + (i - half) * DSTEP;
+                int nd  = ((rd % 360) + 360) % 360;
+                bool ic = (i == half);
+                bool it = _hasTgt && Near(nd, _bearing, TARC);
+                string lbl = Cardinal(nd) ?? $"{nd:000}";
+                if (ic)
+                    sb.Append($"<color={HudVisualTheme.HexWhite}><b>[{lbl}]</b></color>");
+                else if (it)
+                    sb.Append($"<color={HudVisualTheme.GetRiskHex(_risk)}>>>{lbl}</color>");
+                else
+                {
+                    string nc = Cardinal(nd) != null ? (nd == 0 ? "#FFFFFF" : HudVisualTheme.HexIdle) : HudVisualTheme.HexDim;
+                    sb.Append($"<color={nc}>{lbl}</color>");
+                }
+                if (i < STEPS - 1) sb.Append("  ");
+            }
+            return sb.ToString();
+        }
+
+        public void SetTarget(double bearing, RiskLevel risk) { _bearing = bearing; _risk = risk; _hasTgt = true; }
+        public void ClearTarget() { _bearing = double.NaN; _hasTgt = false; _risk = RiskLevel.Low; }
+
+        private static bool Near(int nd, double b, float thr)
+        {
+            if (double.IsNaN(b)) return false;
+            return Mathf.Abs(Mathf.DeltaAngle(nd, (float)b)) <= thr;
+        }
+
+        private static string Cardinal(int d)
+        {
+            switch (d)
+            {
+                case   0: return "N";  case  45: return "NE";
+                case  90: return "E";  case 135: return "SE";
+                case 180: return "S";  case 225: return "SW";
+                case 270: return "W";  case 315: return "NW";
+                default:  return null;
+            }
+        }
+    }
+}

--- a/UnityProject/tfg/Assets/Scripts/Presentation/HUD/HudCompassWidget.cs.meta
+++ b/UnityProject/tfg/Assets/Scripts/Presentation/HUD/HudCompassWidget.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9294fae7031b6594ca705bc7bba9ec9a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/tfg/Assets/Scripts/Presentation/HUD/HudConflictPanel.cs
+++ b/UnityProject/tfg/Assets/Scripts/Presentation/HUD/HudConflictPanel.cs
@@ -1,0 +1,107 @@
+using TMPro; using UnityEngine; using UnityEngine.UI;
+using TFG.ARVisor.Domain.Models;
+namespace TFG.ARVisor.Presentation.HUD {
+[RequireComponent(typeof(Canvas))][RequireComponent(typeof(CanvasGroup))]
+public class HudConflictPanel : MonoBehaviour {
+    const float PW=160f,PH=195f,WS=0.003f;
+    Canvas _cv; CanvasGroup _cg;
+    RawImage _bg,_topLine,_divider;
+    TMP_Text _trafLabel,_callsign,_riskBadge;
+    TMP_Text _lDist,_vDist,_lCpa,_vCpa,_lIn,_vIn,_lDir,_vDir;
+
+    void Awake(){
+        _cv=GetComponent<Canvas>(); _cv.renderMode=RenderMode.WorldSpace; _cv.sortingOrder=98;
+        if(Camera.main!=null)_cv.worldCamera=Camera.main;
+        _cg=GetComponent<CanvasGroup>(); _cg.interactable=false; _cg.blocksRaycasts=false;
+        var rt=GetComponent<RectTransform>(); rt.sizeDelta=new Vector2(PW,PH);
+        transform.localScale=Vector3.one*WS; Build();
+    }
+    void Build(){
+        _bg=Img("BG",transform); Str(_bg.rectTransform); _bg.color=HudVisualTheme.PanelBg;
+        _topLine=Img("TL",transform); var tl=_topLine.rectTransform;
+        tl.anchorMin=new Vector2(0f,1f); tl.anchorMax=new Vector2(1f,1f);
+        tl.pivot=new Vector2(0.5f,1f); tl.offsetMin=Vector2.zero; tl.offsetMax=Vector2.zero; tl.sizeDelta=new Vector2(0f,2f);
+        _topLine.color=HudVisualTheme.ColorIdle;
+        _divider=Img("DIV",transform); var dv=_divider.rectTransform;
+        dv.anchorMin=new Vector2(0.05f,0f); dv.anchorMax=new Vector2(0.95f,0f);
+        dv.pivot=new Vector2(0.5f,0f); dv.anchoredPosition=new Vector2(0f,144f); dv.sizeDelta=new Vector2(0f,0.5f);
+        _divider.color=HudVisualTheme.PanelBorder;
+        _trafLabel=Txt("TL",transform,8f,false); Place(_trafLabel,0f,1f,0f,1f,8f,-5f,-8f,-25f);
+        _trafLabel.text=$"<color={HudVisualTheme.HexDim}>TRAFFIC</color>";
+        _callsign=Txt("CS",transform,15.5f,false); Place(_callsign,0f,1f,0.72f,0.98f,8f,0f,-8f,0f);
+        _riskBadge=Txt("RK",transform,9f,true); Place(_riskBadge,0.5f,1f,0.72f,0.98f,0f,0f,-8f,0f);
+        float rh=0.165f;
+        (_lDist,_vDist)=Row("Dist",0.565f,rh,"DISTANCE");
+        (_lCpa, _vCpa) =Row("Cpa", 0.395f,rh,"CPA");
+        (_lIn,  _vIn)  =Row("In",  0.225f,rh,"IN");
+        (_lDir, _vDir) =Row("Dir", 0.055f,rh,"DIRECTION");
+    }
+    (TMP_Text,TMP_Text) Row(string id,float ancY,float h,string label){
+        var L=Txt("L"+id,transform,9f,false);
+        Place(L,0f,0.5f,ancY,ancY+h,10f,0f,0f,0f);
+        L.text=$"<color={HudVisualTheme.HexDim}>{label}</color>";
+        var V=Txt("V"+id,transform,9.5f,true);
+        Place(V,0.4f,1f,ancY,ancY+h,0f,0f,-10f,0f);
+        V.text=$"<color={HudVisualTheme.HexDim}>--</color>";
+        return (L,V);
+    }
+    static void Place(TMP_Text t,float ax,float bx,float ay,float by,float ol,float ob,float or2,float ot){
+        var r=t.rectTransform;
+        r.anchorMin=new Vector2(ax,ay); r.anchorMax=new Vector2(bx,by);
+        r.offsetMin=new Vector2(ol,ob); r.offsetMax=new Vector2(or2,ot);
+    }
+    public void ShowLow(int n,string dist,string cs=""){
+        if(_topLine)_topLine.color=new Color(0,0,0,0);
+        if(_callsign)_callsign.text=string.IsNullOrWhiteSpace(cs)?"":$"<color={HudVisualTheme.HexDim}>{cs}</color>";
+        if(_riskBadge)_riskBadge.text="";
+        if(_trafLabel)_trafLabel.text="";
+        Set(_vDist,dist,"--",HudVisualTheme.HexDim);
+        if(_lCpa!=null)_lCpa.text="";
+        Set(_vCpa,"","",HudVisualTheme.HexDim);
+        if(_vIn!=null)_vIn.text=$"<color={HudVisualTheme.HexDim}>{n} AC</color>";
+        if(_lIn!=null)_lIn.text=$"<color={HudVisualTheme.HexDim}>NEARBY</color>";
+        if(_vDir!=null)_vDir.text="";
+        if(_lDir!=null)_lDir.text="";
+        Reanchor(_lIn,0.395f,0.165f); Reanchor(_vIn,0.395f,0.165f);
+    }
+    public void ShowMedium(string cs,string dist,string cpa,string tcpa,string dir){
+        if(_topLine)_topLine.color=HudVisualTheme.ColorMedium;
+        if(_trafLabel)_trafLabel.text=$"<color={HudVisualTheme.HexDim}>TRAFFIC</color>";
+        if(_lCpa!=null)_lCpa.text=$"<color={HudVisualTheme.HexDim}>CPA</color>";
+        Reanchor(_lIn,0.225f,0.165f); Reanchor(_vIn,0.225f,0.165f);
+        if(_callsign)_callsign.text=$"<color={HudVisualTheme.HexMedium}>{V(cs,"TARGET")}</color>";
+        if(_riskBadge)_riskBadge.text=$"<color={HudVisualTheme.HexMedium}>MED</color>";
+        Set(_vDist,dist,"--",HudVisualTheme.HexWhite);
+        Set(_vCpa,cpa,"--",HudVisualTheme.HexWhite);
+        Set(_vIn,tcpa,"--",HudVisualTheme.HexMedium);
+        Set(_vDir,dir,"--",HudVisualTheme.HexDim);
+        if(_lIn!=null)_lIn.text=$"<color={HudVisualTheme.HexDim}>IN</color>";
+        if(_lDir!=null)_lDir.text=$"<color={HudVisualTheme.HexDim}>DIRECTION</color>";
+    }
+    public void ShowHigh(string cs,string dist,string cpa,string tcpa,string dir){
+        if(_topLine)_topLine.color=HudVisualTheme.ColorHigh;
+        if(_trafLabel)_trafLabel.text=$"<color={HudVisualTheme.HexDim}>TRAFFIC</color>";
+        if(_lCpa!=null)_lCpa.text=$"<color={HudVisualTheme.HexDim}>CPA</color>";
+        Reanchor(_lIn,0.225f,0.165f); Reanchor(_vIn,0.225f,0.165f);
+        if(_callsign)_callsign.text=$"<color={HudVisualTheme.HexHigh}>{V(cs,"TARGET")}</color>";
+        if(_riskBadge)_riskBadge.text=$"<color={HudVisualTheme.HexHigh}>HIGH</color>";
+        Set(_vDist,dist,"--",HudVisualTheme.HexWhite);
+        Set(_vCpa,cpa,"--",HudVisualTheme.HexWhite);
+        Set(_vIn,tcpa,"--",HudVisualTheme.HexHigh);
+        Set(_vDir,dir,"--",HudVisualTheme.HexHighSoft);
+        if(_lIn!=null)_lIn.text=$"<color={HudVisualTheme.HexDim}>IN</color>";
+        if(_lDir!=null)_lDir.text=$"<color={HudVisualTheme.HexDim}>DIRECTION</color>";
+    }
+    public void ShowEmpty(){
+        if(_callsign)_callsign.text=""; if(_riskBadge)_riskBadge.text="";
+        foreach(var t in new[]{_vDist,_vCpa,_vIn,_vDir}) if(t!=null)t.text="";
+    }
+    public TMP_Text GetCallsignLabel()=>_callsign;
+    static void Set(TMP_Text t,string val,string fb,string col){if(t!=null)t.text=$"<color={col}>{(H(val)?val:fb)}</color>";}
+    static bool H(string v)=>!string.IsNullOrWhiteSpace(v)&&v!="--";
+    static string V(string v,string f)=>H(v)?v:f;
+    static void Reanchor(TMP_Text t,float ancY,float h){ if(t==null)return; var r=t.rectTransform; r.anchorMin=new Vector2(r.anchorMin.x,ancY); r.anchorMax=new Vector2(r.anchorMax.x,ancY+h); }
+    static RawImage Img(string n,Transform p){var go=new GameObject(n,typeof(RectTransform),typeof(CanvasRenderer),typeof(RawImage));go.transform.SetParent(p,false);var i=go.GetComponent<RawImage>();i.texture=UnityEngine.Texture2D.whiteTexture;i.raycastTarget=false;return i;}
+    static TMP_Text Txt(string n,Transform p,float sz,bool right){var go=new GameObject(n,typeof(RectTransform),typeof(CanvasRenderer),typeof(TMPro.TextMeshProUGUI));go.transform.SetParent(p,false);var t=go.GetComponent<TMP_Text>();t.fontSize=sz;t.alignment=right?TMPro.TextAlignmentOptions.Right:TMPro.TextAlignmentOptions.Left;t.enableWordWrapping=false;t.raycastTarget=false;t.richText=true;t.color=HudVisualTheme.ColorWhite;t.text="";return t;}
+    static void Str(RectTransform r){r.anchorMin=Vector2.zero;r.anchorMax=Vector2.one;r.offsetMin=Vector2.zero;r.offsetMax=Vector2.zero;}
+}}

--- a/UnityProject/tfg/Assets/Scripts/Presentation/HUD/HudConflictPanel.cs.meta
+++ b/UnityProject/tfg/Assets/Scripts/Presentation/HUD/HudConflictPanel.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f071c3ec21324e445842565893a09184
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/tfg/Assets/Scripts/Presentation/HUD/HudController.cs
+++ b/UnityProject/tfg/Assets/Scripts/Presentation/HUD/HudController.cs
@@ -1,623 +1,122 @@
-/*
- * HudController.cs
- * ------------------------------------------------------------
- * Este script controla los textos principales del HUD del visor.
- *
- * Su función es recibir datos ya procesados por otros módulos y mostrarlos
- * en pantalla de forma clara y adaptativa:
- * - estado del sistema,
- * - estado del GPS,
- * - tráfico aéreo cercano,
- * - aeronave seleccionada como TARGET,
- * - guía visual según la dirección del target,
- * - predicción inicial de conflicto,
- * - nivel de riesgo,
- * - mensaje superior de alerta,
- * - retícula central.
- *
- * La filosofía del HUD es no saturar al piloto:
- * - LOW: información mínima y discreta.
- * - MED: aviso moderado con CPA/TCPA y guía visual.
- * - HIGH: alerta clara con información crítica y guía visual destacada.
- *
- * Se conecta con:
- * - ExternalGpsProvider: actualiza el panel izquierdo con GPS REAL / WAIT.
- * - OpenSkyApiClient: envía un TrafficSnapshot con tráfico, target y predicción.
- * - TrafficSnapshot: modelo de datos que contiene la información que se muestra.
- */
-
-using System;
-using TFG.ARVisor.Domain.Models;
-using TMPro;
-using UnityEngine;
-
-namespace TFG.ARVisor.Presentation.HUD
-{
-    public class HudController : MonoBehaviour
-    {
-        [Header("HUD Text References")]
-        [SerializeField] private TMP_Text systemText;
-        [SerializeField] private TMP_Text trafficText;
-        [SerializeField] private TMP_Text alertText;
-        [SerializeField] private TMP_Text reticleText;
-
-        [Header("HUD Visual References")]
-        [SerializeField] private WorldTargetBox worldTargetBox;
-
-        /// <summary>
-        /// Inicializa el HUD con valores por defecto para evitar textos vacíos al arrancar la escena.
-        /// </summary>
-        private void Start()
-        {
-            EnableRichText();
-
-            RenderSystemStatus("ONLINE", "SIM", "2D", "1 Hz");
-            RenderTraffic(new TrafficSnapshot(0, "--", RiskLevel.Low, "NO ALERTS"));
-        }
-
-        /// <summary>
-        /// Activa Rich Text en todos los TextMeshPro para poder usar tamaños y colores dentro del texto.
-        /// </summary>
-        private void EnableRichText()
-        {
-            if (systemText != null)
-            {
-                systemText.richText = true;
-            }
-
-            if (trafficText != null)
-            {
-                trafficText.richText = true;
-            }
-
-            if (alertText != null)
-            {
-                alertText.richText = true;
-            }
-
-            if (reticleText != null)
-            {
-                reticleText.richText = true;
-            }
-        }
-
-        /// <summary>
-        /// Actualiza el panel izquierdo del HUD con el estado general del sistema y del GPS.
-        /// </summary>
-        public void RenderSystemStatus(string status, string gpsStatus, string mode, string updateRate)
-        {
-            if (systemText == null)
-            {
-                return;
-            }
-
-            systemText.text =
-                "<size=78%>SYSTEM</size>\n" +
-                $"SYS  {FormatHudValue(status)}\n" +
-                $"GPS  {FormatHudValue(gpsStatus)}\n" +
-                $"MODE {FormatHudValue(mode)}\n" +
-                $"UPD  {FormatHudValue(updateRate)}";
-        }
-
-        /// <summary>
-        /// Actualiza el panel derecho, la alerta superior y la retícula central.
-        /// </summary>
-        public void RenderTraffic(TrafficSnapshot snapshot)
-        {
-            if (trafficText != null)
-            {
-                trafficText.text = BuildTrafficText(snapshot);
-                trafficText.color = new Color(0.9f, 0.9f, 0.9f);
-            }
-
-            UpdateReticle(snapshot);
-
-            if (worldTargetBox != null)
-            {
-                worldTargetBox.RenderBox(snapshot);
-            }
-
-            if (snapshot != null)
-            {
-                RenderAlert(snapshot.AlertMessage, snapshot.RiskLevel);
-            }
-        }
-
-        /// <summary>
-        /// Construye el texto principal del panel derecho de forma adaptativa según el riesgo.
-        /// </summary>
-        private string BuildTrafficText(TrafficSnapshot snapshot)
-        {
-            if (snapshot == null)
-            {
-                return
-                    "<size=78%>AIRSPACE</size>\n" +
-                    "NO DATA\n\n" +
-                    "TRAF --\n" +
-                    "RISK --";
-            }
-
-            string riskLabel = GetRiskLabel(snapshot.RiskLevel);
-            string riskColor = GetRiskHexColor(snapshot.RiskLevel);
-
-            if (snapshot.RiskLevel == RiskLevel.Low)
-            {
-                return BuildLowRiskText(snapshot, riskLabel, riskColor);
-            }
-
-            if (!HasRelevantAircraft(snapshot))
-            {
-                return BuildNoTargetWarningText(snapshot, riskLabel, riskColor);
-            }
-
-            return BuildActiveRiskTargetText(snapshot, riskLabel, riskColor);
-        }
-
-        /// <summary>
-        /// Construye un HUD mínimo cuando no hay riesgo relevante.
-        /// </summary>
-        private string BuildLowRiskText(TrafficSnapshot snapshot, string riskLabel, string riskColor)
-        {
-            string nearestLine = HasRelevantAircraft(snapshot)
-                ? $"NEAREST {snapshot.RelevantCallsign}\n{ExtractSectorName(snapshot.TargetSector)} · {FormatHudValue(snapshot.NearestDistance)}\n"
-                : $"NEAREST {FormatHudValue(snapshot.NearestDistance)}\n";
-
-            string scenarioLine = BuildScenarioLine(snapshot.SelectionMode);
-
-            return
-                "<size=78%>AIRSPACE</size>\n" +
-                "<size=120%>PATH CLEAR</size>\n" +
-                scenarioLine +
-                "\n" +
-                nearestLine +
-                $"TRAF {snapshot.NearbyAircraft}\n" +
-                $"RISK <color={riskColor}>{riskLabel}</color>";
-        }
-
-        /// <summary>
-        /// Construye el HUD cuando hay riesgo medio o alto y existe una aeronave relevante.
-        /// </summary>
-        private string BuildActiveRiskTargetText(TrafficSnapshot snapshot, string riskLabel, string riskColor)
-        {
-            string viewSector = ExtractSectorName(snapshot.ViewSector);
-            string targetSector = ExtractSectorName(snapshot.TargetSector);
-            string selectionMode = FormatSelectionMode(snapshot.SelectionMode);
-            string status = FormatConflictStatus(snapshot.ConflictStatus, snapshot.RiskLevel);
-            string guidance = BuildVisualGuidanceText(snapshot);
-
-            return
-                "<size=78%>AIRSPACE</size>\n" +
-                $"<size=120%><color={riskColor}>{status}</color></size>\n" +
-                BuildCabinSectorLine(snapshot) + "\n" +
-                $"<size=70%>VIEW {viewSector} · {selectionMode}</size>\n" +
-                $"<size=125%>{snapshot.RelevantCallsign}</size>\n" +
-                $"<size=82%>{targetSector} · {FormatHudValue(snapshot.NearestDistance)}</size>\n" +
-                $"<size=74%>{guidance}</size>\n\n" +
-                BuildPredictionBlock(snapshot) +
-                $"ALT  {FormatHudValue(snapshot.RelevantAltitude)}\n" +
-                $"HDG  {FormatHudValue(snapshot.RelevantHeading)}\n" +
-                $"TRAF {snapshot.NearbyAircraft}\n" +
-                $"RISK <color={riskColor}>{riskLabel}</color>";
-        }
-
-        /// <summary>
-        /// Construye el HUD cuando hay riesgo, pero no existe una aeronave relevante que mostrar.
-        /// </summary>
-        private string BuildNoTargetWarningText(TrafficSnapshot snapshot, string riskLabel, string riskColor)
-        {
-            string viewSector = ExtractSectorName(snapshot.ViewSector);
-            string status = FormatConflictStatus(snapshot.ConflictStatus, snapshot.RiskLevel);
-
-            return
-                "<size=78%>AIRSPACE</size>\n" +
-                $"<size=120%><color={riskColor}>{status}</color></size>\n" +
-                $"<size=70%>VIEW {viewSector}</size>\n" +
-                "<size=115%>NO TARGET</size>\n\n" +
-                BuildPredictionBlock(snapshot) +
-                $"TRAF {snapshot.NearbyAircraft}\n" +
-                $"NEAR {FormatHudValue(snapshot.NearestDistance)}\n" +
-                $"RISK <color={riskColor}>{riskLabel}</color>";
-        }
-
-        /// <summary>
-        /// Construye una línea compacta de sectores de cabina.
-        /// No es un radar real: indica en qué sector relativo está el target.
-        /// </summary>
-        private string BuildCabinSectorLine(TrafficSnapshot snapshot)
-        {
-            string targetSector = snapshot != null
-                ? ExtractSectorName(snapshot.TargetSector)
-                : "--";
-
-            RiskLevel riskLevel = snapshot != null
-                ? snapshot.RiskLevel
-                : RiskLevel.Low;
-
-            string front = BuildSectorDot("FRONT", targetSector, riskLevel);
-            string left = BuildSectorDot("LEFT", targetSector, riskLevel);
-            string right = BuildSectorDot("RIGHT", targetSector, riskLevel);
-            string rear = BuildSectorDot("REAR", targetSector, riskLevel);
-
-            return $"<size=72%>SECTOR F{front}  L{left}  R{right}  B{rear}</size>";
-        }
-
-        /// <summary>
-        /// Devuelve el punto de sector para indicar dónde está el target.
-        /// </summary>
-        private string BuildSectorDot(string sectorName, string targetSector, RiskLevel riskLevel)
-        {
-            if (targetSector == sectorName)
-            {
-                return $"<color={GetRiskHexColor(riskLevel)}>●</color>";
-            }
-
-            return "·";
-        }
-
-        /// <summary>
-        /// Construye el bloque de predicción del HUD.
-        /// En LOW se oculta CPA/TCPA para no saturar.
-        /// En MED/HIGH se muestra CPA/TCPA porque es información crítica.
-        /// </summary>
-        private string BuildPredictionBlock(TrafficSnapshot snapshot)
-        {
-            if (snapshot == null)
-            {
-                return "";
-            }
-
-            bool hasCpa = HasDisplayValue(snapshot.ClosestApproachDistance);
-            bool hasTcpa = HasDisplayValue(snapshot.TimeToClosestApproach);
-
-            if (!hasCpa || !hasTcpa)
-            {
-                return "PRED WAIT\n";
-            }
-
-            if (snapshot.RiskLevel == RiskLevel.Low)
-            {
-                return "";
-            }
-
-            return
-                $"CPA  {snapshot.ClosestApproachDistance}\n" +
-                $"IN   {snapshot.TimeToClosestApproach}\n";
-        }
-
-        /// <summary>
-        /// Construye una línea opcional para indicar que se está usando un escenario de prueba.
-        /// </summary>
-        private string BuildScenarioLine(string selectionMode)
-        {
-            if (string.IsNullOrWhiteSpace(selectionMode))
-            {
-                return "";
-            }
-
-            string upper = selectionMode.ToUpperInvariant();
-
-            if (!upper.Contains("SCENARIO"))
-            {
-                return "";
-            }
-
-            return $"<size=64%>{selectionMode}</size>\n";
-        }
-
-        /// <summary>
-        /// Comprueba si el snapshot contiene una aeronave destacada.
-        /// </summary>
-        private bool HasRelevantAircraft(TrafficSnapshot snapshot)
-        {
-            return snapshot != null &&
-                   !string.IsNullOrWhiteSpace(snapshot.RelevantCallsign);
-        }
-
-        /// <summary>
-        /// Comprueba si un valor textual es realmente mostrable.
-        /// </summary>
-        private bool HasDisplayValue(string value)
-        {
-            return !string.IsNullOrWhiteSpace(value) &&
-                   value != "--";
-        }
-
-        /// <summary>
-        /// Extrae el nombre del sector desde textos como VIEW LEFT o SECTOR RIGHT.
-        /// </summary>
-        private string ExtractSectorName(string sectorText)
-        {
-            if (string.IsNullOrWhiteSpace(sectorText))
-            {
-                return "--";
-            }
-
-            string upper = sectorText.ToUpperInvariant();
-
-            if (upper.Contains("FRONT"))
-            {
-                return "FRONT";
-            }
-
-            if (upper.Contains("RIGHT"))
-            {
-                return "RIGHT";
-            }
-
-            if (upper.Contains("LEFT"))
-            {
-                return "LEFT";
-            }
-
-            if (upper.Contains("REAR"))
-            {
-                return "REAR";
-            }
-
-            return "--";
-        }
-
-        /// <summary>
-        /// Simplifica el modo de selección para mostrarlo compacto en el HUD.
-        /// </summary>
-        private string FormatSelectionMode(string selectionMode)
-        {
-            if (string.IsNullOrWhiteSpace(selectionMode))
-            {
-                return "NO LOCK";
-            }
-
-            string upper = selectionMode.ToUpperInvariant();
-
-            if (upper.Contains("SCENARIO"))
-            {
-                return "TEST MODE";
-            }
-
-            if (upper.Contains("CONFLICT"))
-            {
-                return "CONFLICT";
-            }
-
-            if (upper.Contains("VIEW"))
-            {
-                return "VIEW LOCK";
-            }
-
-            if (upper.Contains("NEAREST"))
-            {
-                return "NEAREST";
-            }
-
-            return selectionMode;
-        }
-
-        /// <summary>
-        /// Simplifica el estado de conflicto para mostrarlo como encabezado principal.
-        /// </summary>
-        private string FormatConflictStatus(string conflictStatus, RiskLevel riskLevel)
-        {
-            if (riskLevel == RiskLevel.High)
-            {
-                return "CONFLICT RISK";
-            }
-
-            if (riskLevel == RiskLevel.Medium)
-            {
-                return "TRAJECTORY WATCH";
-            }
-
-            if (string.IsNullOrWhiteSpace(conflictStatus))
-            {
-                return "PATH CLEAR";
-            }
-
-            string upper = conflictStatus.ToUpperInvariant();
-
-            if (upper.Contains("CONFLICT"))
-            {
-                return "CONFLICT RISK";
-            }
-
-            if (upper.Contains("WATCH"))
-            {
-                return "TRAJECTORY WATCH";
-            }
-
-            return "PATH CLEAR";
-        }
-
-        /// <summary>
-        /// Actualiza la retícula central según el nivel de riesgo y la dirección angular del target.
-        /// </summary>
-        private void UpdateReticle(TrafficSnapshot snapshot)
-        {
-            if (reticleText == null)
-            {
-                return;
-            }
-
-            if (snapshot == null || !HasRelevantAircraft(snapshot) || snapshot.RiskLevel == RiskLevel.Low)
-            {
-                reticleText.text = "+";
-                reticleText.color = new Color(0.85f, 0.85f, 0.85f);
-                return;
-            }
-
-            reticleText.text = BuildReticleMarker(snapshot);
-            reticleText.color = GetRiskColor(snapshot.RiskLevel);
-        }
-
-        /// <summary>
-        /// Construye el marcador central del HUD según la posición angular del target respecto a la mirada.
-        /// </summary>
-        private string BuildReticleMarker(TrafficSnapshot snapshot)
-        {
-            if (snapshot == null || !snapshot.TargetViewOffsetDegrees.HasValue)
-            {
-                return snapshot != null && snapshot.RiskLevel == RiskLevel.High ? "[!]" : "[+]";
-            }
-
-            double offset = snapshot.TargetViewOffsetDegrees.Value;
-            double absoluteOffset = Math.Abs(offset);
-
-            if (absoluteOffset <= 12.0)
-            {
-                return snapshot.RiskLevel == RiskLevel.High ? "[!]" : "[+]";
-            }
-
-            if (absoluteOffset <= 45.0)
-            {
-                return offset > 0.0 ? "+ >" : "< +";
-            }
-
-            if (absoluteOffset <= 120.0)
-            {
-                return offset > 0.0 ? ">>" : "<<";
-            }
-
-            return "v";
-        }
-
-        /// <summary>
-        /// Construye una indicación textual breve para orientar al piloto hacia el target.
-        /// Solo se muestra cuando el riesgo es MED/HIGH.
-        /// </summary>
-        private string BuildVisualGuidanceText(TrafficSnapshot snapshot)
-        {
-            if (snapshot == null || !HasRelevantAircraft(snapshot))
-            {
-                return "";
-            }
-
-            if (snapshot.RiskLevel == RiskLevel.Low)
-            {
-                return "";
-            }
-
-            if (!snapshot.TargetViewOffsetDegrees.HasValue)
-            {
-                return "TARGET DIRECTION --";
-            }
-
-            double offset = snapshot.TargetViewOffsetDegrees.Value;
-            double absoluteOffset = Math.Abs(offset);
-
-            if (absoluteOffset <= 12.0)
-            {
-                return "TARGET CENTERED";
-            }
-
-            if (absoluteOffset <= 45.0)
-            {
-                return offset > 0.0
-                    ? "SLIGHT RIGHT >"
-                    : "< SLIGHT LEFT";
-            }
-
-            if (absoluteOffset <= 120.0)
-            {
-                return offset > 0.0
-                    ? "LOOK RIGHT >>"
-                    : "<< LOOK LEFT";
-            }
-
-            return "TARGET BEHIND";
-        }
-
-        /// <summary>
-        /// Actualiza el mensaje superior de alerta y lo hace más visible según el nivel de riesgo.
-        /// En LOW se deja vacío para no invadir el campo de visión.
-        /// </summary>
-        private void RenderAlert(string message, RiskLevel riskLevel)
-        {
-            if (alertText == null)
-            {
-                return;
-            }
-
-            string safeMessage = string.IsNullOrWhiteSpace(message)
-                ? "NO ALERTS"
-                : message;
-
-            switch (riskLevel)
-            {
-                case RiskLevel.High:
-                    alertText.text = $"!!! {safeMessage} !!!";
-                    break;
-
-                case RiskLevel.Medium:
-                    alertText.text = $"-- {safeMessage} --";
-                    break;
-
-                default:
-                    alertText.text = "";
-                    break;
-            }
-
-            alertText.color = GetRiskColor(riskLevel);
-        }
-
-        /// <summary>
-        /// Devuelve el color visual asociado a cada nivel de riesgo.
-        /// </summary>
-        private Color GetRiskColor(RiskLevel riskLevel)
-        {
-            switch (riskLevel)
-            {
-                case RiskLevel.High:
-                    return new Color(1f, 0.2f, 0.2f);
-
-                case RiskLevel.Medium:
-                    return new Color(1f, 0.8f, 0.2f);
-
-                default:
-                    return new Color(0.85f, 0.85f, 0.85f);
-            }
-        }
-
-        /// <summary>
-        /// Devuelve el color hexadecimal usado por TextMeshPro para colorear partes concretas del HUD.
-        /// </summary>
-        private string GetRiskHexColor(RiskLevel riskLevel)
-        {
-            switch (riskLevel)
-            {
-                case RiskLevel.High:
-                    return "#FF3333";
-
-                case RiskLevel.Medium:
-                    return "#FFCC33";
-
-                default:
-                    return "#E6E6E6";
-            }
-        }
-
-        /// <summary>
-        /// Devuelve el texto corto que representa el nivel de riesgo en el HUD.
-        /// </summary>
-        private string GetRiskLabel(RiskLevel riskLevel)
-        {
-            switch (riskLevel)
-            {
-                case RiskLevel.High:
-                    return "HIGH";
-
-                case RiskLevel.Medium:
-                    return "MED";
-
-                default:
-                    return "LOW";
-            }
-        }
-
-        /// <summary>
-        /// Devuelve un valor seguro para mostrar en el HUD cuando un dato opcional no está disponible.
-        /// </summary>
-        private string FormatHudValue(string value)
-        {
-            return string.IsNullOrWhiteSpace(value) ? "--" : value;
+using System; using TFG.ARVisor.Domain.Models; using TMPro; using UnityEngine;
+namespace TFG.ARVisor.Presentation.HUD {
+public class HudController : MonoBehaviour {
+    [Header("Scene Refs")]
+    [SerializeField] TMP_Text systemText;
+    [SerializeField] TMP_Text trafficText;
+    [SerializeField] TMP_Text alertText;
+    [SerializeField] TMP_Text reticleText;
+    [SerializeField] WorldTargetBox worldTargetBox;
+
+    HudAlertBanner      _alert;
+    HudCompassStrip     _compass;
+    HudConflictPanel    _conflict;
+    HudStatusWidget     _status;
+    HudLoadingIndicator _loader;
+    HudAnimator         _anim;
+
+    void Awake(){ HideOld(); Build(); _anim=gameObject.AddComponent<HudAnimator>(); }
+    void Start(){
+        _status?.Render("ONLINE","WAIT","SIM","1 Hz");
+        _conflict?.ShowLow(0,"--");
+        _loader?.Show("SCANNING AIRSPACE");
+        _alert?.Hide();
+        if(alertText!=null){ alertText.richText=true; alertText.gameObject.SetActive(false); }
+        if(reticleText!=null){ reticleText.richText=true; reticleText.text=$"<color={HudVisualTheme.HexDim}>+</color>"; reticleText.color=Color.white; }
+    }
+    void HideOld(){ Kill(systemText); Kill(trafficText); }
+    static void Kill(TMP_Text t){ if(t!=null)t.color=new Color(0,0,0,0); }
+
+    void Build(){
+        Transform lp   = systemText!=null ? systemText.transform.parent : null;
+        Transform root = lp!=null ? lp.parent : transform;
+        _alert   = Spawn<HudAlertBanner>   ("HUD_Alert",    root, new Vector3(0f,    0.78f, 2.5f));
+        _compass = Spawn<HudCompassStrip>  ("HUD_Compass",  root, new Vector3(0f,    0.56f, 2.5f));
+        _conflict= Spawn<HudConflictPanel> ("HUD_Conflict", root, new Vector3( 1.082f, -0.092f, 2.5f));
+        _status  = Spawn<HudStatusWidget>  ("HUD_Status",   root, new Vector3(-1.173f,  0.073f, 2.5f));
+        _loader  = Spawn<HudLoadingIndicator>("HUD_Load",   root, new Vector3(0.212f, 0.44f, 2.5f));
+    }
+    static T Spawn<T>(string name, Transform parent, Vector3 pos) where T : MonoBehaviour {
+        var go = new GameObject(name, typeof(RectTransform), typeof(Canvas), typeof(CanvasGroup));
+        go.transform.SetParent(parent, false);
+        go.transform.localPosition = pos;
+        go.transform.localRotation = Quaternion.identity;
+        go.transform.localScale    = Vector3.one;
+        return go.AddComponent<T>();
+    }
+
+    public void RenderSystemStatus(string status, string gpsStatus, string mode, string updateRate){
+        bool sim = mode!=null && mode.ToUpperInvariant().Contains("SIM");
+        if(sim)               _status?.RenderSimMode(status);
+        else if(gpsStatus=="WAIT") _status?.RenderWaiting();
+        else                  _status?.Render(status,gpsStatus,mode,updateRate);
+    }
+    public void RenderGpsCoordinates(double lat, double lon, double? alt){
+        _status?.SetCoordinates(lat,lon,alt);
+    }
+    public void RenderTraffic(TrafficSnapshot s){
+        if(s==null){ NoData(); return; }
+        _loader?.Hide();
+        worldTargetBox?.RenderBox(s);
+        UpdateReticle(s);
+        switch(s.RiskLevel){
+            case RiskLevel.Low:    DoLow(s);    break;
+            case RiskLevel.Medium: DoMedium(s); break;
+            case RiskLevel.High:   DoHigh(s);   break;
         }
     }
-}
+    void DoLow(TrafficSnapshot s){
+        _anim?.StopAll();
+        _alert?.Hide();
+        if(alertText!=null) alertText.gameObject.SetActive(false);
+        _conflict?.ShowLow(s.NearbyAircraft, s.NearestDistance, s.RelevantCallsign);
+        _compass?.ClearTarget();
+    }
+    void DoMedium(TrafficSnapshot s){
+        _alert?.ShowMedium(Msg(s,"TRAFFIC ADVISORY"));
+        if(alertText!=null) alertText.gameObject.SetActive(false);
+        _conflict?.ShowMedium(s.RelevantCallsign,s.NearestDistance,s.ClosestApproachDistance,s.TimeToClosestApproach,Guide(s));
+        var hdr=_conflict?.GetCallsignLabel();
+        if(hdr!=null)_anim?.StartPulse(hdr,HudVisualTheme.ColorMedium,HudVisualTheme.ColorWhite,1.6f);
+        CompassTarget(s);
+    }
+    void DoHigh(TrafficSnapshot s){
+        _alert?.ShowHigh(Msg(s,"CONFLICT ALERT"));
+        if(alertText!=null) alertText.gameObject.SetActive(false);
+        _conflict?.ShowHigh(s.RelevantCallsign,s.NearestDistance,s.ClosestApproachDistance,s.TimeToClosestApproach,Guide(s));
+        var hdr=_conflict?.GetCallsignLabel();
+        if(hdr!=null)_anim?.StartPulse(hdr,HudVisualTheme.ColorHigh,new Color(1f,0.7f,0.7f),2.4f);
+        CompassTarget(s);
+    }
+    void NoData(){
+        _conflict?.ShowEmpty(); _loader?.Show("NO TRAFFIC DATA");
+        _compass?.ClearTarget(); _anim?.StopAll(); _alert?.Hide();
+        worldTargetBox?.RenderBox(null); UpdateReticle(null);
+    }
+    void CompassTarget(TrafficSnapshot s){
+        if(_compass==null||!s.TargetViewOffsetDegrees.HasValue||string.IsNullOrWhiteSpace(s.RelevantCallsign)){ _compass?.ClearTarget(); return; }
+        float yaw = Camera.main!=null ? Camera.main.transform.eulerAngles.y : 0f;
+        _compass.SetTarget(yaw+s.TargetViewOffsetDegrees.Value, s.RiskLevel);
+    }
+    void UpdateReticle(TrafficSnapshot s){
+        if(reticleText==null) return;
+        if(s==null||s.RiskLevel==RiskLevel.Low||string.IsNullOrWhiteSpace(s.RelevantCallsign)){
+            reticleText.text=$"<color={HudVisualTheme.HexDim}>+</color>"; reticleText.color=Color.white; return;
+        }
+        reticleText.color=HudVisualTheme.GetRiskColor(s.RiskLevel);
+        if(!s.TargetViewOffsetDegrees.HasValue){ reticleText.text=s.RiskLevel==RiskLevel.High?$"<color={HudVisualTheme.HexHigh}>[!]</color>":"[+]"; return; }
+        double off=s.TargetViewOffsetDegrees.Value, abs=Math.Abs(off);
+        string hex=HudVisualTheme.GetRiskHex(s.RiskLevel); bool hi=s.RiskLevel==RiskLevel.High;
+        if(abs<=12)  reticleText.text=$"<color={hex}>{(hi?"[!]":"[+]")}</color>";
+        else if(abs<=45)  reticleText.text=$"<color={hex}>{(off>0?"+  >":"<  +")}</color>";
+        else if(abs<=120) reticleText.text=$"<color={hex}>{(off>0?">>":"<<")}</color>";
+        else reticleText.text=$"<color={hex}>v</color>";
+    }
+    static string Msg(TrafficSnapshot s,string fb)=>string.IsNullOrWhiteSpace(s.AlertMessage)?fb:s.AlertMessage;
+    static string Guide(TrafficSnapshot s){
+        if(!s.TargetViewOffsetDegrees.HasValue)return"--";
+        double off=s.TargetViewOffsetDegrees.Value,abs=Math.Abs(off);
+        if(abs<=12)return"CENTERED"; if(abs<=45)return off>0?"SLIGHT RIGHT >":"< SLIGHT LEFT";
+        if(abs<=120)return off>0?"LOOK RIGHT >>":"<< LOOK LEFT"; return"BEHIND";
+    }
+}}

--- a/UnityProject/tfg/Assets/Scripts/Presentation/HUD/HudLoadingIndicator.cs
+++ b/UnityProject/tfg/Assets/Scripts/Presentation/HUD/HudLoadingIndicator.cs
@@ -1,0 +1,43 @@
+using TMPro; using UnityEngine; using UnityEngine.UI;
+namespace TFG.ARVisor.Presentation.HUD {
+[RequireComponent(typeof(Canvas))][RequireComponent(typeof(CanvasGroup))]
+public class HudLoadingIndicator : MonoBehaviour {
+    const float PW=300f,PH=28f,WS=0.003f;
+    const float SI=0.15f;
+    Canvas _cv; CanvasGroup _cg;
+    TMP_Text _spin,_msg;
+    float _t; int _f;
+    void Awake(){
+        _cv=GetComponent<Canvas>(); _cv.renderMode=RenderMode.WorldSpace; _cv.sortingOrder=97;
+        if(Camera.main!=null)_cv.worldCamera=Camera.main;
+        _cg=GetComponent<CanvasGroup>(); _cg.interactable=false; _cg.blocksRaycasts=false;
+        var rt=GetComponent<RectTransform>(); rt.sizeDelta=new Vector2(PW,PH);
+        transform.localScale=Vector3.one*WS; Build(); gameObject.SetActive(false);
+    }
+    void Build(){
+        _spin=T("S",transform,8.5f,TMPro.TextAlignmentOptions.Center);
+        var sr=_spin.rectTransform;
+        sr.anchorMin=new Vector2(0f,0f); sr.anchorMax=new Vector2(0.12f,1f);
+        sr.offsetMin=new Vector2(0f,0f); sr.offsetMax=Vector2.zero;
+        _spin.color=HudVisualTheme.ColorDim; _spin.text="|";
+        _msg=T("M",transform,8.5f,TMPro.TextAlignmentOptions.Left);
+        var mr=_msg.rectTransform;
+        mr.anchorMin=new Vector2(0.12f,0f); mr.anchorMax=new Vector2(1f,1f);
+        mr.offsetMin=new Vector2(4f,0f); mr.offsetMax=new Vector2(-4f,0f);
+        _msg.color=HudVisualTheme.ColorDim; _msg.text="SCANNING AIRSPACE";
+    }
+    void Update(){
+        _t+=Time.deltaTime; if(_t<SI)return; _t=0f;
+        _f=(_f+1)%HudVisualTheme.SpinnerFrames.Length;
+        if(_spin!=null)_spin.text=HudVisualTheme.SpinnerFrames[_f].ToString();
+    }
+    public void Show(string msg){ gameObject.SetActive(true); if(_msg!=null)_msg.text=msg; }
+    public void Hide(){ gameObject.SetActive(false); }
+    static TMP_Text T(string n,Transform p,float sz,TMPro.TextAlignmentOptions a){
+        var go=new GameObject(n,typeof(RectTransform),typeof(CanvasRenderer),typeof(TMPro.TextMeshProUGUI));
+        go.transform.SetParent(p,false);
+        var t=go.GetComponent<TMP_Text>();
+        t.fontSize=sz; t.alignment=a; t.enableWordWrapping=false; t.raycastTarget=false;
+        t.richText=true; t.color=HudVisualTheme.ColorDim; t.text=""; return t;
+    }
+}}

--- a/UnityProject/tfg/Assets/Scripts/Presentation/HUD/HudLoadingIndicator.cs.meta
+++ b/UnityProject/tfg/Assets/Scripts/Presentation/HUD/HudLoadingIndicator.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6b34aff9b0daed544b7a9ce4f3e35833
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/tfg/Assets/Scripts/Presentation/HUD/HudStatusWidget.cs
+++ b/UnityProject/tfg/Assets/Scripts/Presentation/HUD/HudStatusWidget.cs
@@ -1,0 +1,71 @@
+using System; using TMPro; using UnityEngine; using UnityEngine.UI;
+namespace TFG.ARVisor.Presentation.HUD {
+[RequireComponent(typeof(Canvas))][RequireComponent(typeof(CanvasGroup))]
+public class HudStatusWidget : MonoBehaviour {
+    const float PW=120f,PH=85f,WS=0.003f;
+    Canvas _cv; CanvasGroup _cg;
+    RawImage _bg,_topL;
+    RawImage[] _bars=new RawImage[4];
+    TMP_Text _modeLabel,_sysLabel,_coordTxt;
+    string _gps="WAIT",_mode="--";
+    static readonly float[] BAR_H={5f,9f,13f,17f};
+
+    void Awake(){
+        _cv=GetComponent<Canvas>(); _cv.renderMode=RenderMode.WorldSpace; _cv.sortingOrder=98;
+        if(Camera.main!=null)_cv.worldCamera=Camera.main;
+        _cg=GetComponent<CanvasGroup>(); _cg.interactable=false; _cg.blocksRaycasts=false;
+        var rt=GetComponent<RectTransform>(); rt.sizeDelta=new Vector2(PW,PH);
+        transform.localScale=Vector3.one*WS; Build();
+    }
+    void Build(){
+        _bg=I("BG",transform); S(_bg.rectTransform); _bg.color=HudVisualTheme.PanelBg;
+        _topL=I("TL",transform); var tl=_topL.rectTransform;
+        tl.anchorMin=new Vector2(0f,1f); tl.anchorMax=new Vector2(1f,1f);
+        tl.pivot=new Vector2(0.5f,1f); tl.offsetMin=Vector2.zero; tl.offsetMax=Vector2.zero; tl.sizeDelta=new Vector2(0f,2f);
+        _topL.color=HudVisualTheme.ColorIdle;
+        for(int i=0;i<4;i++){
+            _bars[i]=I("B"+i,transform); var br=_bars[i].rectTransform;
+            br.anchorMin=new Vector2(0f,0f); br.anchorMax=new Vector2(0f,0f);
+            br.pivot=new Vector2(0f,0f);
+            br.anchoredPosition=new Vector2(10f+i*7f,38f);
+            br.sizeDelta=new Vector2(4f,BAR_H[i]);
+            _bars[i].color=HudVisualTheme.ColorDim;
+        }
+        _modeLabel=T("ML",transform,9.5f,false); var mr=_modeLabel.rectTransform;
+        mr.anchorMin=new Vector2(0f,0.5f); mr.anchorMax=new Vector2(1f,1f);
+        mr.offsetMin=new Vector2(44f,2f); mr.offsetMax=new Vector2(-6f,-2f);
+        _sysLabel=T("SL",transform,8f,false); var sr=_sysLabel.rectTransform;
+        sr.anchorMin=new Vector2(0f,0.25f); sr.anchorMax=new Vector2(1f,0.52f);
+        sr.offsetMin=new Vector2(10f,0f); sr.offsetMax=new Vector2(-6f,0f);
+        _coordTxt=T("CT",transform,8f,false); var cr=_coordTxt.rectTransform;
+        cr.anchorMin=new Vector2(0f,0f); cr.anchorMax=new Vector2(1f,0.27f);
+        cr.offsetMin=new Vector2(10f,2f); cr.offsetMax=new Vector2(-6f,0f);
+        _coordTxt.text=$"<color={HudVisualTheme.HexDim}>--  --</color>";
+    }
+    public void Render(string sys,string gps,string mode,string rate){_gps=gps;_mode=mode;Ref();}
+    public void RenderWaiting(){_gps="WAIT";_mode="--";Ref();if(_coordTxt)_coordTxt.text=$"<color={HudVisualTheme.HexDim}>--  --</color>";}
+    public void RenderSimMode(string sys){_gps="SIM";_mode="SIM";Ref();if(_coordTxt)_coordTxt.text=$"<color={HudVisualTheme.HexDim}>SIM MODE</color>";}
+    public void SetCoordinates(double? lat,double? lon,double? alt){
+        if(_coordTxt==null)return;
+        if(!lat.HasValue||!lon.HasValue){_coordTxt.text=$"<color={HudVisualTheme.HexDim}>--  --</color>";return;}
+        string ls=$"{Math.Abs(lat.Value):0.000}{(lat.Value>=0?"N":"S")}";
+        string lo=$"{Math.Abs(lon.Value):0.000}{(lon.Value>=0?"E":"W")}";
+        _coordTxt.text=$"<color={HudVisualTheme.HexDim}>{ls}  {lo}</color>";
+    }
+    void Ref(){
+        bool ok=_gps=="REAL",sim=_gps=="SIM",d3=_mode=="3D";
+        int lit=ok?4:sim?0:1;
+        Color bc=ok?HudVisualTheme.ColorLow:sim?HudVisualTheme.ColorDim:HudVisualTheme.ColorMedium;
+        for(int i=0;i<4;i++) if(_bars[i]) _bars[i].color=i<lit?bc:new Color(0.25f,0.25f,0.25f,0.5f);
+        if(_topL)_topL.color=ok?HudVisualTheme.ColorLow:sim?HudVisualTheme.ColorDim:HudVisualTheme.ColorMedium;
+        if(_modeLabel==null)return;
+        string gc=ok?HudVisualTheme.HexLow:sim?HudVisualTheme.HexDim:HudVisualTheme.HexMedium;
+        string mc=d3?HudVisualTheme.HexLow:HudVisualTheme.HexDim;
+        string gl=ok?"GPS OK":sim?"GPS SIM":"GPS WAIT";
+        _modeLabel.text=$"<color={gc}>{gl}</color>  <color={mc}>{_mode}</color>";
+        if(_sysLabel)_sysLabel.text=$"<color={HudVisualTheme.HexDim}>SYS ONLINE</color>";
+    }
+    static RawImage I(string n,Transform p){var go=new GameObject(n,typeof(RectTransform),typeof(CanvasRenderer),typeof(RawImage));go.transform.SetParent(p,false);var i=go.GetComponent<RawImage>();i.texture=UnityEngine.Texture2D.whiteTexture;i.raycastTarget=false;return i;}
+    static TMP_Text T(string n,Transform p,float sz,bool r){var go=new GameObject(n,typeof(RectTransform),typeof(CanvasRenderer),typeof(TMPro.TextMeshProUGUI));go.transform.SetParent(p,false);var t=go.GetComponent<TMP_Text>();t.fontSize=sz;t.alignment=r?TMPro.TextAlignmentOptions.Right:TMPro.TextAlignmentOptions.Left;t.enableWordWrapping=false;t.raycastTarget=false;t.richText=true;t.color=HudVisualTheme.ColorWhite;t.text="";return t;}
+    static void S(RectTransform rt){rt.anchorMin=Vector2.zero;rt.anchorMax=Vector2.one;rt.offsetMin=Vector2.zero;rt.offsetMax=Vector2.zero;}
+}}

--- a/UnityProject/tfg/Assets/Scripts/Presentation/HUD/HudStatusWidget.cs.meta
+++ b/UnityProject/tfg/Assets/Scripts/Presentation/HUD/HudStatusWidget.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3caa936e44ef6f94488b5c0ffc8cac39
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/tfg/Assets/Scripts/Presentation/HUD/HudThreatWidget.cs
+++ b/UnityProject/tfg/Assets/Scripts/Presentation/HUD/HudThreatWidget.cs
@@ -1,0 +1,87 @@
+/*
+ * HudThreatWidget.cs  —  v0.10-alpha
+ * Widget compacto de amenaza. Reemplaza el panel derecho del HUD.
+ * LOW: una linea discreta. MED/HIGH: header + datos + guia.
+ */
+using TMPro;
+using UnityEngine;
+
+namespace TFG.ARVisor.Presentation.HUD
+{
+    public class HudThreatWidget : MonoBehaviour
+    {
+        private TMP_Text _headerLine;
+        private TMP_Text _dataLine;
+        private TMP_Text _guidanceLine;
+
+        private void Awake()
+        {
+            _headerLine   = MakeLine("HUD_ThreatHeader",    0.00f, 5.5f);
+            _dataLine     = MakeLine("HUD_ThreatData",     -0.09f, 4.5f);
+            _guidanceLine = MakeLine("HUD_ThreatGuidance", -0.17f, 4.0f);
+        }
+
+        private TMP_Text MakeLine(string name, float localY, float fontSize)
+        {
+            var go = new GameObject(name);
+            go.transform.SetParent(transform, false);
+            go.transform.localPosition = new Vector3(0f, localY, 0f);
+            go.transform.localRotation = Quaternion.identity;
+            go.transform.localScale    = Vector3.one * HudVisualTheme.DefaultWorldScale;
+            var tmp                    = go.AddComponent<TextMeshPro>();
+            tmp.fontSize               = fontSize;
+            tmp.alignment              = TextAlignmentOptions.Right;
+            tmp.enableWordWrapping     = false;
+            tmp.raycastTarget          = false;
+            tmp.richText               = true;
+            tmp.color                  = HudVisualTheme.ColorWhite;
+            tmp.text                   = "";
+            return tmp;
+        }
+
+        public void RenderLow(int nearbyCount, string nearestDistance)
+        {
+            if (_headerLine == null) return;
+            string dist = HasVal(nearestDistance) ? $"  <color={HudVisualTheme.HexDim}>{nearestDistance}</color>" : "";
+            _headerLine.text = $"<color={HudVisualTheme.HexLow}>CLEAR</color><color={HudVisualTheme.HexDim}>  {nearbyCount} AC{dist}</color>";
+            Set(_dataLine, "");
+            Set(_guidanceLine, "");
+        }
+
+        public void RenderMedium(string callsign, string distance, string cpa, string tcpa, string guidance)
+        {
+            if (_headerLine == null) return;
+            _headerLine.text = $"<color={HudVisualTheme.HexMedium}>TRAJECTORY WATCH</color>";
+            _dataLine.text   = DataLine(HudVisualTheme.HexMedium, callsign, distance, cpa, tcpa);
+            SetGuide(guidance, HudVisualTheme.HexDim);
+        }
+
+        public void RenderHigh(string callsign, string distance, string cpa, string tcpa, string guidance)
+        {
+            if (_headerLine == null) return;
+            _headerLine.text = $"<color={HudVisualTheme.HexHigh}>CONFLICT</color>";
+            _dataLine.text   = DataLine(HudVisualTheme.HexHigh, callsign, distance, cpa, tcpa);
+            SetGuide(guidance, HudVisualTheme.HexHighSoft);
+        }
+
+        public void RenderEmpty()
+        {
+            Set(_headerLine, ""); Set(_dataLine, ""); Set(_guidanceLine, "");
+        }
+
+        public TMP_Text GetHeaderLine() => _headerLine;
+
+        private string DataLine(string cc, string cs, string d, string c, string t) =>
+            $"<color={cc}>{S(cs,"TARGET")}</color><color={HudVisualTheme.HexDim}>  {S(d,"--")}  CPA {S(c,"--")}  IN {S(t,"--")}</color>";
+
+        private void SetGuide(string text, string col)
+        {
+            if (_guidanceLine == null) return;
+            _guidanceLine.text = HasVal(text) ? $"<color={col}>{text}</color>" : "";
+        }
+
+        private static void Set(TMP_Text t, string v) { if (t != null) t.text = v; }
+        private static bool HasVal(string v) => !string.IsNullOrWhiteSpace(v) && v != "--";
+        private static string S(string v, string f) => HasVal(v) ? v : f;
+    }
+}

--- a/UnityProject/tfg/Assets/Scripts/Presentation/HUD/HudThreatWidget.cs.meta
+++ b/UnityProject/tfg/Assets/Scripts/Presentation/HUD/HudThreatWidget.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 22b03a15b10c72e4b96ec32e46260cce
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/tfg/Assets/Scripts/Presentation/HUD/HudVisualTheme.cs
+++ b/UnityProject/tfg/Assets/Scripts/Presentation/HUD/HudVisualTheme.cs
@@ -1,0 +1,29 @@
+using TFG.ARVisor.Domain.Models;
+using UnityEngine;
+namespace TFG.ARVisor.Presentation.HUD {
+public static class HudVisualTheme {
+    public static readonly Color ColorLow    = new Color(0.40f,0.82f,0.60f,1f);
+    public static readonly Color ColorMedium = new Color(1.00f,0.78f,0.28f,1f);
+    public static readonly Color ColorHigh   = new Color(1.00f,0.32f,0.26f,1f);
+    public static readonly Color ColorIdle   = new Color(0.55f,0.70f,0.60f,0.80f);
+    public static readonly Color ColorDim    = new Color(0.45f,0.45f,0.45f,0.70f);
+    public static readonly Color ColorWhite  = new Color(0.92f,0.92f,0.92f,1f);
+    public static readonly Color PanelBg     = new Color(0.04f,0.05f,0.04f,0.28f);
+    public static readonly Color PanelBorder = new Color(1f,1f,1f,0.14f);
+    public const string HexLow    = "#66D199";
+    public const string HexMedium = "#FFC847";
+    public const string HexHigh   = "#FF5242";
+    public const string HexIdle   = "#8CB89B";
+    public const string HexDim    = "#737373";
+    public const string HexWhite  = "#EBEBEB";
+    public const string HexHighSoft = "#FF9980";
+    public const float DefaultWorldScale = 0.1f;
+    public const float DefaultFontSize   = 5f;
+    public static readonly char[] SpinnerFrames = {'|','/','-','\\'};
+    public static Color GetRiskColor(RiskLevel r) {
+        switch(r){ case RiskLevel.High: return ColorHigh; case RiskLevel.Medium: return ColorMedium; default: return ColorLow; }
+    }
+    public static string GetRiskHex(RiskLevel r) {
+        switch(r){ case RiskLevel.High: return HexHigh; case RiskLevel.Medium: return HexMedium; default: return HexLow; }
+    }
+}}

--- a/UnityProject/tfg/Assets/Scripts/Presentation/HUD/HudVisualTheme.cs.meta
+++ b/UnityProject/tfg/Assets/Scripts/Presentation/HUD/HudVisualTheme.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 103ab5f39a42f694a9c2a6c356d8efdf
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/tfg/Assets/Scripts/Presentation/HUD/WorldTargetBox.cs
+++ b/UnityProject/tfg/Assets/Scripts/Presentation/HUD/WorldTargetBox.cs
@@ -1,12 +1,20 @@
 /*
- * WorldTargetBox.cs
+ * WorldTargetBox.cs  —  v0.10-alpha Visual Redesign
  * ------------------------------------------------------------
- * Caja pseudo-AR para marcar visualmente el target en el campo de visión.
+ * Caja pseudo-AR de seguimiento tipo visor de combate.
+ *
+ * Mejoras respecto a la versión anterior:
+ *   - Fade in/out suave (lerp alpha en lugar de snap).
+ *   - Scan-line animada que barre la caja verticalmente en estado HIGH.
+ *   - Esquinas más finas y elegantes.
+ *   - Label mínimo: callsign + distancia, o callsign + IN si hay TCPA en HIGH.
+ *   - Fondo translúcido levemente más visible en HIGH.
+ *   - Posición estable con lerp suavizado.
+ *   - Se oculta si el target sale del campo visual.
  *
  * No modifica la retícula central.
- * No es texto flotante del HUD 2D.
  * Es un Canvas en World Space que se coloca delante de la cámara en la dirección
- * aproximada del target.
+ * aproximada del target según TargetViewOffsetDegrees del snapshot.
  */
 
 using System;
@@ -21,409 +29,379 @@ namespace TFG.ARVisor.Presentation.HUD
     [RequireComponent(typeof(CanvasGroup))]
     public class WorldTargetBox : MonoBehaviour
     {
+        // ── Inspector ─────────────────────────────────────────────────
         [Header("References")]
         [SerializeField] private Transform viewerCamera;
 
         [Header("Visibility")]
-        [SerializeField] private bool showInLowRisk = false;
+        [SerializeField] private bool  showInLowRisk          = false;
         [SerializeField] private float maxVisibleAngleDegrees = 70f;
 
         [Header("World Placement")]
         [SerializeField] private float markerDistanceMeters = 12f;
         [SerializeField] private float verticalOffsetMeters = -0.15f;
-        [SerializeField] private float smoothSpeed = 10f;
+        [SerializeField] private float smoothSpeed          = 8f;
 
         [Header("Box Style")]
-        [SerializeField] private Vector2 mediumBoxSize = new Vector2(180f, 90f);
-        [SerializeField] private Vector2 highBoxSize = new Vector2(220f, 105f);
-        [SerializeField] private float worldScale = 0.0035f;
-        [SerializeField] private float cornerLength = 34f;
-        [SerializeField] private float cornerThickness = 4f;
-        [SerializeField] private float backgroundAlpha = 0.12f;
-        [SerializeField] private float highPulseSpeed = 4f;
-        [SerializeField] private float highPulseAmount = 0.18f;
+        [SerializeField] private Vector2 mediumBoxSize    = new Vector2(180f, 90f);
+        [SerializeField] private Vector2 highBoxSize      = new Vector2(220f, 110f);
+        [SerializeField] private float   worldScale       = 0.0035f;
+        [SerializeField] private float   cornerLength     = 28f;
+        [SerializeField] private float   cornerThickness  = 2.5f;
+        [SerializeField] private float   backgroundAlpha  = 0.10f;
+        [SerializeField] private float   fadeSpeed        = 6f;
+
+        [Header("HIGH Pulse")]
+        [SerializeField] private float highPulseSpeed  = 3.5f;
+        [SerializeField] private float highPulseAmount = 0.14f;
+
+        [Header("Scan Line")]
+        [SerializeField] private bool  showScanLine       = true;
+        [SerializeField] private float scanLineSpeed      = 0.8f;   // cycles per second
+        [SerializeField] private float scanLineThickness  = 2f;
+        [SerializeField] private float scanLineAlpha      = 0.35f;
 
         [Header("Label")]
-        [SerializeField] private int mediumFontSize = 20;
-        [SerializeField] private int highFontSize = 24;
+        [SerializeField] private int mediumFontSize = 18;
+        [SerializeField] private int highFontSize   = 22;
 
-        private Canvas canvas;
-        private CanvasGroup canvasGroup;
-        private RectTransform rootRect;
+        // ── Runtime refs ─────────────────────────────────────────────
+        private Canvas      _canvas;
+        private CanvasGroup _canvasGroup;
+        private RectTransform _rootRect;
 
-        private RectTransform boxRoot;
-        private RawImage background;
+        private RectTransform _boxRoot;
+        private RawImage      _background;
 
-        private RawImage topLeftH;
-        private RawImage topLeftV;
-        private RawImage topRightH;
-        private RawImage topRightV;
-        private RawImage bottomLeftH;
-        private RawImage bottomLeftV;
-        private RawImage bottomRightH;
-        private RawImage bottomRightV;
+        private RawImage _tl_h, _tl_v;
+        private RawImage _tr_h, _tr_v;
+        private RawImage _bl_h, _bl_v;
+        private RawImage _br_h, _br_v;
 
-        private TMP_Text label;
+        private RawImage _scanLine;
+        private TMP_Text _label;
 
-        private Vector3 targetWorldPosition;
-        private Vector2 targetBoxSize;
-        private RiskLevel currentRisk;
-        private bool visible;
+        // ── State ─────────────────────────────────────────────────────
+        private Vector3   _targetWorldPos;
+        private Vector2   _targetBoxSize;
+        private RiskLevel _currentRisk;
+        private bool      _visible;
+        private float     _scanPhase;
+
+        // ── Unity ─────────────────────────────────────────────────────
 
         private void Awake()
         {
-            canvas = GetComponent<Canvas>();
-            canvasGroup = GetComponent<CanvasGroup>();
-            rootRect = GetComponent<RectTransform>();
+            _canvas      = GetComponent<Canvas>();
+            _canvasGroup = GetComponent<CanvasGroup>();
+            _rootRect    = GetComponent<RectTransform>();
 
-            canvas.renderMode = RenderMode.WorldSpace;
-            canvas.sortingOrder = 100;
+            _canvas.renderMode   = RenderMode.WorldSpace;
+            _canvas.sortingOrder = 100;
 
             if (viewerCamera == null && Camera.main != null)
             {
-                viewerCamera = Camera.main.transform;
-                canvas.worldCamera = Camera.main;
+                viewerCamera       = Camera.main.transform;
+                _canvas.worldCamera = Camera.main;
             }
 
             transform.localScale = Vector3.one * worldScale;
 
             BuildBox();
-            HideImmediate();
+            SetAlpha(0f);
         }
 
         private void Update()
         {
-            if (!visible || viewerCamera == null)
-            {
-                return;
-            }
+            if (viewerCamera == null) return;
 
+            // Smooth fade
+            float targetAlpha = _visible ? 1f : 0f;
+            float current     = _canvasGroup.alpha;
+            _canvasGroup.alpha = Mathf.MoveTowards(current, targetAlpha, Time.deltaTime * fadeSpeed);
+
+            if (!_visible && _canvasGroup.alpha <= 0.01f) return;
+
+            // Position tracking
             transform.position = Vector3.Lerp(
                 transform.position,
-                targetWorldPosition,
-                Time.deltaTime * smoothSpeed
-            );
+                _targetWorldPos,
+                Time.deltaTime * smoothSpeed);
 
-            Vector3 lookDirection = transform.position - viewerCamera.position;
+            // Always face camera
+            Vector3 dir = transform.position - viewerCamera.position;
+            if (dir.sqrMagnitude > 0.001f)
+                transform.rotation = Quaternion.LookRotation(dir.normalized, Vector3.up);
 
-            if (lookDirection.sqrMagnitude > 0.001f)
-            {
-                transform.rotation = Quaternion.LookRotation(lookDirection.normalized, Vector3.up);
-            }
+            // Box size
+            _boxRoot.sizeDelta = Vector2.Lerp(
+                _boxRoot.sizeDelta,
+                _targetBoxSize,
+                Time.deltaTime * smoothSpeed);
 
-            boxRoot.sizeDelta = Vector2.Lerp(
-                boxRoot.sizeDelta,
-                targetBoxSize,
-                Time.deltaTime * smoothSpeed
-            );
-
-            if (currentRisk == RiskLevel.High)
+            // Pulse scale (HIGH only)
+            if (_currentRisk == RiskLevel.High)
             {
                 float pulse = 1f + Mathf.Sin(Time.time * highPulseSpeed) * highPulseAmount;
-                boxRoot.localScale = new Vector3(pulse, pulse, 1f);
+                _boxRoot.localScale = new Vector3(pulse, pulse, 1f);
             }
             else
             {
-                boxRoot.localScale = Vector3.Lerp(
-                    boxRoot.localScale,
+                _boxRoot.localScale = Vector3.Lerp(
+                    _boxRoot.localScale,
                     Vector3.one,
-                    Time.deltaTime * smoothSpeed
-                );
+                    Time.deltaTime * smoothSpeed);
+            }
+
+            // Scan line (HIGH only)
+            if (_scanLine != null)
+            {
+                bool scanActive = _currentRisk == RiskLevel.High && showScanLine && _visible;
+                _scanLine.gameObject.SetActive(scanActive);
+
+                if (scanActive)
+                {
+                    _scanPhase = (_scanPhase + Time.deltaTime * scanLineSpeed) % 1f;
+                    float boxH = _boxRoot.sizeDelta.y;
+                    float yPos = Mathf.Lerp(-boxH * 0.5f, boxH * 0.5f, _scanPhase);
+
+                    var rt = _scanLine.rectTransform;
+                    rt.anchoredPosition = new Vector2(0f, yPos);
+                    rt.sizeDelta        = new Vector2(_boxRoot.sizeDelta.x, scanLineThickness);
+                }
             }
         }
 
-        /// <summary>
-        /// Recibe los datos actuales y decide si la caja debe mostrarse.
-        /// </summary>
+        // ── Public API ────────────────────────────────────────────────
+
         public void RenderBox(TrafficSnapshot snapshot)
         {
             if (snapshot == null || !HasTarget(snapshot))
             {
-                Hide();
+                _visible = false;
                 return;
             }
 
             if (snapshot.RiskLevel == RiskLevel.Low && !showInLowRisk)
             {
-                Hide();
+                _visible = false;
                 return;
             }
 
             if (!snapshot.TargetViewOffsetDegrees.HasValue)
             {
-                Hide();
+                _visible = false;
                 return;
             }
 
             double offset = snapshot.TargetViewOffsetDegrees.Value;
-
             if (Math.Abs(offset) > maxVisibleAngleDegrees)
             {
-                Hide();
+                _visible = false;
                 return;
             }
 
-            currentRisk = snapshot.RiskLevel;
+            _currentRisk     = snapshot.RiskLevel;
+            _targetWorldPos  = ComputeWorldPosition(offset);
+            _targetBoxSize   = snapshot.RiskLevel == RiskLevel.High ? highBoxSize : mediumBoxSize;
 
-            Color riskColor = GetRiskColor(snapshot.RiskLevel);
+            Color riskColor = HudVisualTheme.GetRiskColor(snapshot.RiskLevel);
             ApplyColor(riskColor, snapshot.RiskLevel);
 
-            targetWorldPosition = CalculateWorldPosition(offset);
-            targetBoxSize = snapshot.RiskLevel == RiskLevel.High
-                ? highBoxSize
-                : mediumBoxSize;
-
-            if (label != null)
+            if (_label != null)
             {
-                label.text = BuildLabel(snapshot);
-                label.color = riskColor;
-                label.fontSize = snapshot.RiskLevel == RiskLevel.High
-                    ? highFontSize
-                    : mediumFontSize;
+                _label.text     = BuildLabel(snapshot);
+                _label.color    = riskColor;
+                _label.fontSize = snapshot.RiskLevel == RiskLevel.High ? highFontSize : mediumFontSize;
             }
 
-            Show();
+            _visible = true;
         }
 
-        /// <summary>
-        /// Calcula una posición en el mundo delante de la cámara según el ángulo horizontal del target.
-        /// </summary>
-        private Vector3 CalculateWorldPosition(double offsetDegrees)
-        {
-            Quaternion horizontalRotation = Quaternion.AngleAxis((float)offsetDegrees, Vector3.up);
-            Vector3 direction = horizontalRotation * viewerCamera.forward;
+        // ── Internal build ────────────────────────────────────────────
 
-            return viewerCamera.position +
-                   direction.normalized * markerDistanceMeters +
-                   Vector3.up * verticalOffsetMeters;
-        }
-
-        /// <summary>
-        /// Construye visualmente la caja con esquinas y etiqueta.
-        /// </summary>
         private void BuildBox()
         {
-            rootRect.sizeDelta = highBoxSize;
+            _rootRect.sizeDelta = highBoxSize;
 
-            boxRoot = CreateRect("TargetLockBox", transform);
-            boxRoot.anchorMin = new Vector2(0.5f, 0.5f);
-            boxRoot.anchorMax = new Vector2(0.5f, 0.5f);
-            boxRoot.pivot = new Vector2(0.5f, 0.5f);
-            boxRoot.anchoredPosition = Vector2.zero;
-            boxRoot.sizeDelta = mediumBoxSize;
+            // Box root
+            _boxRoot                     = CreateRect("TargetLockBox", transform);
+            _boxRoot.anchorMin           = new Vector2(0.5f, 0.5f);
+            _boxRoot.anchorMax           = new Vector2(0.5f, 0.5f);
+            _boxRoot.pivot               = new Vector2(0.5f, 0.5f);
+            _boxRoot.anchoredPosition    = Vector2.zero;
+            _boxRoot.sizeDelta           = mediumBoxSize;
 
-            background = CreateRawImage("Background", boxRoot);
-            StretchToParent(background.rectTransform);
+            // Background
+            _background = CreateImage("Background", _boxRoot);
+            Stretch(_background.rectTransform);
 
-            topLeftH = CreateRawImage("TopLeft_H", boxRoot);
-            topLeftV = CreateRawImage("TopLeft_V", boxRoot);
-            topRightH = CreateRawImage("TopRight_H", boxRoot);
-            topRightV = CreateRawImage("TopRight_V", boxRoot);
-            bottomLeftH = CreateRawImage("BottomLeft_H", boxRoot);
-            bottomLeftV = CreateRawImage("BottomLeft_V", boxRoot);
-            bottomRightH = CreateRawImage("BottomRight_H", boxRoot);
-            bottomRightV = CreateRawImage("BottomRight_V", boxRoot);
-
+            // Corners
+            _tl_h = CreateImage("TL_H", _boxRoot);
+            _tl_v = CreateImage("TL_V", _boxRoot);
+            _tr_h = CreateImage("TR_H", _boxRoot);
+            _tr_v = CreateImage("TR_V", _boxRoot);
+            _bl_h = CreateImage("BL_H", _boxRoot);
+            _bl_v = CreateImage("BL_V", _boxRoot);
+            _br_h = CreateImage("BR_H", _boxRoot);
+            _br_v = CreateImage("BR_V", _boxRoot);
             LayoutCorners();
 
-            label = CreateLabel("TargetLabel", boxRoot);
+            // Scan line (hidden by default)
+            _scanLine                    = CreateImage("ScanLine", _boxRoot);
+            _scanLine.color              = new Color(1f, 1f, 1f, scanLineAlpha);
+            var slRect                   = _scanLine.rectTransform;
+            slRect.anchorMin             = new Vector2(0.5f, 0.5f);
+            slRect.anchorMax             = new Vector2(0.5f, 0.5f);
+            slRect.pivot                 = new Vector2(0.5f, 0.5f);
+            slRect.sizeDelta             = new Vector2(mediumBoxSize.x, scanLineThickness);
+            slRect.anchoredPosition      = Vector2.zero;
+            _scanLine.gameObject.SetActive(false);
+
+            // Label
+            _label = CreateLabel("TargetLabel", _boxRoot);
         }
 
         private void LayoutCorners()
         {
-            SetCorner(topLeftH.rectTransform, 0f, 1f, cornerLength, cornerThickness, cornerLength * 0.5f, -cornerThickness * 0.5f);
-            SetCorner(topLeftV.rectTransform, 0f, 1f, cornerThickness, cornerLength, cornerThickness * 0.5f, -cornerLength * 0.5f);
+            float cl = cornerLength;
+            float ct = cornerThickness;
 
-            SetCorner(topRightH.rectTransform, 1f, 1f, cornerLength, cornerThickness, -cornerLength * 0.5f, -cornerThickness * 0.5f);
-            SetCorner(topRightV.rectTransform, 1f, 1f, cornerThickness, cornerLength, -cornerThickness * 0.5f, -cornerLength * 0.5f);
-
-            SetCorner(bottomLeftH.rectTransform, 0f, 0f, cornerLength, cornerThickness, cornerLength * 0.5f, cornerThickness * 0.5f);
-            SetCorner(bottomLeftV.rectTransform, 0f, 0f, cornerThickness, cornerLength, cornerThickness * 0.5f, cornerLength * 0.5f);
-
-            SetCorner(bottomRightH.rectTransform, 1f, 0f, cornerLength, cornerThickness, -cornerLength * 0.5f, cornerThickness * 0.5f);
-            SetCorner(bottomRightV.rectTransform, 1f, 0f, cornerThickness, cornerLength, -cornerThickness * 0.5f, cornerLength * 0.5f);
+            SetCorner(_tl_h.rectTransform, 0f, 1f,  cl, ct,  cl * 0.5f, -ct * 0.5f);
+            SetCorner(_tl_v.rectTransform, 0f, 1f,  ct, cl,  ct * 0.5f, -cl * 0.5f);
+            SetCorner(_tr_h.rectTransform, 1f, 1f,  cl, ct, -cl * 0.5f, -ct * 0.5f);
+            SetCorner(_tr_v.rectTransform, 1f, 1f,  ct, cl, -ct * 0.5f, -cl * 0.5f);
+            SetCorner(_bl_h.rectTransform, 0f, 0f,  cl, ct,  cl * 0.5f,  ct * 0.5f);
+            SetCorner(_bl_v.rectTransform, 0f, 0f,  ct, cl,  ct * 0.5f,  cl * 0.5f);
+            SetCorner(_br_h.rectTransform, 1f, 0f,  cl, ct, -cl * 0.5f,  ct * 0.5f);
+            SetCorner(_br_v.rectTransform, 1f, 0f,  ct, cl, -ct * 0.5f,  cl * 0.5f);
         }
 
-        private void SetCorner(
-            RectTransform rect,
-            float anchorX,
-            float anchorY,
-            float width,
-            float height,
-            float posX,
-            float posY)
+        private static void SetCorner(RectTransform rt, float ax, float ay,
+                                      float w, float h, float px, float py)
         {
-            rect.anchorMin = new Vector2(anchorX, anchorY);
-            rect.anchorMax = new Vector2(anchorX, anchorY);
-            rect.pivot = new Vector2(0.5f, 0.5f);
-            rect.sizeDelta = new Vector2(width, height);
-            rect.anchoredPosition = new Vector2(posX, posY);
+            rt.anchorMin        = new Vector2(ax, ay);
+            rt.anchorMax        = new Vector2(ax, ay);
+            rt.pivot            = new Vector2(0.5f, 0.5f);
+            rt.sizeDelta        = new Vector2(w, h);
+            rt.anchoredPosition = new Vector2(px, py);
         }
 
-        private TMP_Text CreateLabel(string objectName, Transform parent)
+        private Vector3 ComputeWorldPosition(double offsetDegrees)
         {
-            GameObject child = new GameObject(objectName, typeof(RectTransform), typeof(CanvasRenderer), typeof(TextMeshProUGUI));
-            child.transform.SetParent(parent, false);
+            Quaternion rot = Quaternion.AngleAxis((float)offsetDegrees, Vector3.up);
+            Vector3    dir = rot * viewerCamera.forward;
 
-            RectTransform rect = child.GetComponent<RectTransform>();
-            rect.anchorMin = Vector2.zero;
-            rect.anchorMax = Vector2.one;
-            rect.offsetMin = new Vector2(10f, 10f);
-            rect.offsetMax = new Vector2(-10f, -10f);
-
-            TMP_Text text = child.GetComponent<TMP_Text>();
-            text.alignment = TextAlignmentOptions.Center;
-            text.fontStyle = FontStyles.Bold;
-            text.enableWordWrapping = false;
-            text.raycastTarget = false;
-
-            return text;
+            return viewerCamera.position
+                 + dir.normalized * markerDistanceMeters
+                 + Vector3.up * verticalOffsetMeters;
         }
 
-        private RawImage CreateRawImage(string objectName, Transform parent)
+        private string BuildLabel(TrafficSnapshot snapshot)
         {
-            GameObject child = new GameObject(objectName, typeof(RectTransform), typeof(CanvasRenderer), typeof(RawImage));
-            child.transform.SetParent(parent, false);
+            string callsign = string.IsNullOrWhiteSpace(snapshot.RelevantCallsign)
+                ? "TARGET"
+                : snapshot.RelevantCallsign;
 
-            RawImage image = child.GetComponent<RawImage>();
-            image.texture = Texture2D.whiteTexture;
-            image.raycastTarget = false;
+            string distance = string.IsNullOrWhiteSpace(snapshot.NearestDistance)
+                              || snapshot.NearestDistance == "--"
+                ? ""
+                : snapshot.NearestDistance;
 
-            return image;
+            bool hasTcpa = !string.IsNullOrWhiteSpace(snapshot.TimeToClosestApproach)
+                        && snapshot.TimeToClosestApproach != "--";
+
+            if (snapshot.RiskLevel == RiskLevel.High && hasTcpa)
+                return $"{callsign}\nIN {snapshot.TimeToClosestApproach}";
+
+            if (!string.IsNullOrWhiteSpace(distance))
+                return $"{callsign}\n{distance}";
+
+            return callsign;
         }
-
-        private RectTransform CreateRect(string objectName, Transform parent)
-        {
-            GameObject child = new GameObject(objectName, typeof(RectTransform));
-            child.transform.SetParent(parent, false);
-            return child.GetComponent<RectTransform>();
-        }
-
-        private void StretchToParent(RectTransform rect)
-        {
-            rect.anchorMin = Vector2.zero;
-            rect.anchorMax = Vector2.one;
-            rect.offsetMin = Vector2.zero;
-            rect.offsetMax = Vector2.zero;
-        }
-
-       private string BuildLabel(TrafficSnapshot snapshot)
-{
-    string callsign = string.IsNullOrWhiteSpace(snapshot.RelevantCallsign)
-        ? "TARGET"
-        : snapshot.RelevantCallsign;
-
-    string distance = string.IsNullOrWhiteSpace(snapshot.NearestDistance)
-        ? "--"
-        : snapshot.NearestDistance;
-
-    string timeToConflict = string.IsNullOrWhiteSpace(snapshot.TimeToClosestApproach) ||
-                            snapshot.TimeToClosestApproach == "--"
-        ? ""
-        : snapshot.TimeToClosestApproach;
-
-    if (snapshot.RiskLevel == RiskLevel.High)
-    {
-        if (!string.IsNullOrWhiteSpace(timeToConflict))
-        {
-            return $"{callsign}\n{distance}\nIN {timeToConflict}";
-        }
-
-        return $"{callsign}\n{distance}";
-    }
-
-    if (snapshot.RiskLevel == RiskLevel.Medium)
-    {
-        if (!string.IsNullOrWhiteSpace(timeToConflict))
-        {
-            return $"{callsign}\n{distance}\nIN {timeToConflict}";
-        }
-
-        return $"{callsign}\n{distance}";
-    }
-
-    return $"{callsign}\n{distance}";
-}
 
         private void ApplyColor(Color color, RiskLevel risk)
         {
-            SetColor(topLeftH, color);
-            SetColor(topLeftV, color);
-            SetColor(topRightH, color);
-            SetColor(topRightV, color);
-            SetColor(bottomLeftH, color);
-            SetColor(bottomLeftV, color);
-            SetColor(bottomRightH, color);
-            SetColor(bottomRightV, color);
+            Color[] corners = { color, color, color, color, color, color, color, color };
+            RawImage[] images = { _tl_h, _tl_v, _tr_h, _tr_v, _bl_h, _bl_v, _br_h, _br_v };
+            for (int i = 0; i < images.Length; i++)
+                if (images[i] != null) images[i].color = corners[i];
 
-            if (background != null)
+            if (_background != null)
             {
-                Color bg = color;
-                bg.a = risk == RiskLevel.High
-                    ? backgroundAlpha * 1.8f
-                    : backgroundAlpha;
+                Color bg  = color;
+                bg.a      = risk == RiskLevel.High ? backgroundAlpha * 2f : backgroundAlpha;
+                _background.color = bg;
+            }
 
-                background.color = bg;
+            if (_scanLine != null)
+            {
+                Color sc  = color;
+                sc.a      = scanLineAlpha;
+                _scanLine.color = sc;
             }
         }
 
-        private void SetColor(RawImage image, Color color)
+        private void SetAlpha(float a)
         {
-            if (image != null)
+            if (_canvasGroup != null)
             {
-                image.color = color;
+                _canvasGroup.alpha          = a;
+                _canvasGroup.interactable   = false;
+                _canvasGroup.blocksRaycasts = false;
             }
         }
 
-        private Color GetRiskColor(RiskLevel riskLevel)
+        private static bool HasTarget(TrafficSnapshot s)
         {
-            switch (riskLevel)
-            {
-                case RiskLevel.High:
-                    return new Color(1f, 0.2f, 0.2f);
-
-                case RiskLevel.Medium:
-                    return new Color(1f, 0.85f, 0.25f);
-
-                default:
-                    return new Color(0.85f, 0.85f, 0.85f);
-            }
+            return s != null && !string.IsNullOrWhiteSpace(s.RelevantCallsign);
         }
 
-        private bool HasTarget(TrafficSnapshot snapshot)
+        // ── UI helpers ────────────────────────────────────────────────
+
+        private static RectTransform CreateRect(string name, Transform parent)
         {
-            return snapshot != null &&
-                   !string.IsNullOrWhiteSpace(snapshot.RelevantCallsign);
+            var go = new GameObject(name, typeof(RectTransform));
+            go.transform.SetParent(parent, false);
+            return go.GetComponent<RectTransform>();
         }
 
-        private void Show()
+        private static RawImage CreateImage(string name, Transform parent)
         {
-            visible = true;
-
-            if (canvasGroup != null)
-            {
-                canvasGroup.alpha = 1f;
-                canvasGroup.interactable = false;
-                canvasGroup.blocksRaycasts = false;
-            }
+            var go  = new GameObject(name, typeof(RectTransform), typeof(CanvasRenderer), typeof(RawImage));
+            go.transform.SetParent(parent, false);
+            var img = go.GetComponent<RawImage>();
+            img.texture       = Texture2D.whiteTexture;
+            img.raycastTarget = false;
+            return img;
         }
 
-        private void Hide()
+        private static TMP_Text CreateLabel(string name, Transform parent)
         {
-            visible = false;
+            var go = new GameObject(name,
+                typeof(RectTransform), typeof(CanvasRenderer), typeof(TextMeshProUGUI));
+            go.transform.SetParent(parent, false);
 
-            if (canvasGroup != null)
-            {
-                canvasGroup.alpha = 0f;
-                canvasGroup.interactable = false;
-                canvasGroup.blocksRaycasts = false;
-            }
+            var rt          = go.GetComponent<RectTransform>();
+            rt.anchorMin    = Vector2.zero;
+            rt.anchorMax    = Vector2.one;
+            rt.offsetMin    = new Vector2(8f,  8f);
+            rt.offsetMax    = new Vector2(-8f, -8f);
+
+            var tmp         = go.GetComponent<TMP_Text>();
+            tmp.alignment   = TextAlignmentOptions.Center;
+            tmp.fontStyle   = FontStyles.Bold;
+            tmp.enableWordWrapping = false;
+            tmp.raycastTarget     = false;
+            return tmp;
         }
 
-        private void HideImmediate()
+        private static void Stretch(RectTransform rt)
         {
-            visible = false;
-            Hide();
+            rt.anchorMin  = Vector2.zero;
+            rt.anchorMax  = Vector2.one;
+            rt.offsetMin  = Vector2.zero;
+            rt.offsetMax  = Vector2.zero;
         }
     }
 }


### PR DESCRIPTION
## Qué se ha hecho

- Se ha rediseñado visualmente el HUD para hacerlo más limpio, minimalista y adecuado para un visor AR de uso civil/comercial.
- Se ha reducido la cantidad de texto visible.
- Se han reorganizado los datos en widgets visuales.
- Se ha mejorado la visualización de los estados LOW, MED y HIGH.
- Se mantiene la caja pseudo-AR del target.
- Se conserva la guía visual hacia el target.
- Se integra la brújula superior como elemento de orientación.
- Se ha mejorado la presentación del tráfico cercano y del riesgo de conflicto.

## Pruebas realizadas

- SafeParallel muestra AIRSPACE CLEAR sin elementos invasivos.
- CrossingTraffic muestra aviso de tráfico y caja amarilla.
- HeadOnConflict muestra conflicto y caja roja.
- La brújula y los widgets visuales se muestran correctamente.
- El proyecto compila en Unity.
- La lógica de riesgo, OpenSky, CPA/TCPA y seguimiento dinámico no se ha modificado.

## Próximo paso

- Preparar build standalone en Meta Quest.